### PR TITLE
Add content-type based on method

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -51,7 +51,6 @@ class BaseClient {
     let requestBody
     if (request) {
       requestBody = JSON.stringify(casters.castRequest(request))
-      options.headers['Content-Type'] = 'application/json'
       options.headers['Content-Length'] = Buffer.byteLength(requestBody)
     }
 
@@ -102,7 +101,8 @@ class BaseClient {
     options.headers = {
       'Accept': `application/vnd.recurly.${this.apiVersion()}`,
       'User-Agent': `Recurly/${pkg.version}; ${pkg.name}`,
-      'Authorization': 'Basic ' + Buffer.from(this.apiKey + ':', 'ascii').toString('base64')
+      'Authorization': 'Basic ' + Buffer.from(this.apiKey + ':', 'ascii').toString('base64'),
+      'Content-Type': 'application/json'
     }
 
     return options


### PR DESCRIPTION
It appears V3 validates the content type based on the request method to prevent against CSRF attacks:
https://github.com/recurly/recurly-app/blob/0a9aac63d0c7327d68f508bc8722169dff2da6da/app/controllers/v3/base_controller.rb#L323-L329

If this is correct (and I don't see why it should change, it's probably fine) then the Node client should also set the Content-Type header based on the same criteria.