### PR TITLE
Allow for a lack of body in the API response

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -62,8 +62,11 @@ class BaseClient {
         response.setEncoding('utf8')
         response.on('data', (chunk) => body.push(chunk))
         response.on('end', () => {
-          let jsonBody = JSON.parse(body.join(''))
-          // console.log('Got Response: ', jsonBody)
+          let jsonBody
+          if (body.length > 0) {
+            jsonBody = JSON.parse(body.join(''))
+            // console.log('Got Response: ', jsonBody)
+          }
 
           let deprecated = response.headers['Recurly-Deprecated'] || ''
           if (!this['_ignore_deprecation_warning'] && deprecated.toUpperCase() === 'TRUE') {

--- a/lib/recurly/Caster.js
+++ b/lib/recurly/Caster.js
@@ -3,7 +3,7 @@ const resources = require('./resources')
 const dtRegex = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z)?$/
 
 function className (obj) {
-  const objName = obj.object
+  const objName = obj && obj.object
   if (!objName) return null
   return objName
     .replace(/_([a-z])/g, g => g[1].toUpperCase())


### PR DESCRIPTION
There are certain API endpoints that return no body. `JSON.parse` cannot handle parsing `undefined`, and `[].join('')` returns undefined. This change allows for the jsonBody to be null and handled properly.