### PR TITLE
Don't let the API key be an instance variable

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -20,9 +20,9 @@ class BaseClient {
   constructor (apiKey, siteId) {
     this.siteId = siteId
 
-    // TODO: Ensure that this value is not logged when an instance is printed
-    // Can this be something other than an instance variable?
-    this.apiKey = apiKey
+    // API key should not be instance variable.
+    // This way it's not accidentally logged.
+    this._getApiKey = () => apiKey
 
     this._httpOptions = {
       host: 'partner-api.recurly.com',
@@ -101,7 +101,7 @@ class BaseClient {
     options.headers = {
       'Accept': `application/vnd.recurly.${this.apiVersion()}`,
       'User-Agent': `Recurly/${pkg.version}; ${pkg.name}`,
-      'Authorization': 'Basic ' + Buffer.from(this.apiKey + ':', 'ascii').toString('base64'),
+      'Authorization': 'Basic ' + Buffer.from(this._getApiKey() + ':', 'ascii').toString('base64'),
       'Content-Type': 'application/json'
     }
 


### PR DESCRIPTION
The API key was previously logged when you would log the `Client` object. This changes it so that it just logs `_getApiKey: [Function]` rather than the API key itself.