### PR TITLE
Install devDependencies when running playground init

### DIFF
--- a/scripts/install-deps
+++ b/scripts/install-deps
@@ -20,4 +20,6 @@ if ! hash node 2>/dev/null; then
   fi
 else
   echo "✓ Found node"
+
+npm install
 fi


### PR DESCRIPTION
I recently re-ran `pg init` and I had to subsequently cd into the node folder to run npm install to get `standard`. Since the name of this script is `install-deps`, I figure we should actually install the dependencies.