### PR TITLE
Fix user agent

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -107,7 +107,7 @@ class BaseClient {
     // for deep cloning
     options.headers = {
       'Accept': `application/vnd.recurly.${this.apiVersion()}`,
-      'User-Agent': `Recurly/${pkg.version}; ${pkg.name}`,
+      'User-Agent': `Recurly/${pkg.version}; node`,
       'Authorization': 'Basic ' + Buffer.from(this._getApiKey() + ':', 'ascii').toString('base64'),
       'Content-Type': 'application/json'
     }

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -19,7 +19,7 @@ describe('BaseClient', () => {
     it('Should set the internal state and headers', () => {
       assert.equal(client.siteId, 'subdomain-mysubdomain')
       assert.equal(client._getDefaultOptions().headers['Authorization'], 'Basic bXlhcGlrZXk6')
-      assert.equal(client._getDefaultOptions().headers['User-Agent'], `Recurly/${pkg.version}; ${pkg.name}`)
+      assert.equal(client._getDefaultOptions().headers['User-Agent'], `Recurly/${pkg.version}; node`)
       assert.equal(client._getDefaultOptions().headers['Accept'], 'application/vnd.recurly.v2020-01-01')
     })
   })


### PR DESCRIPTION
Agent said `recurly-client-node` but we changed the package name to
`recurly` when publishing. This makes sure that we follow the format:
Recurly/$version; $lang