### PR TITLE
Url Encode Items in interpolatePath

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -40,7 +40,7 @@ class BaseClient {
   _interpolatePath (path, parameters = {}) {
     parameters['site_id'] = this.siteId
     Object.keys(parameters).forEach(name => {
-      path = path.replace(`{${name}}`, parameters[name])
+      path = path.replace(`{${name}}`, encodeURIComponent(parameters[name].toString()))
     })
     return path
   }

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -27,11 +27,11 @@ describe('BaseClient', () => {
     it('Should interpolate the path with the given params', () => {
       const pathTmpl = '/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
       const path = client._interpolatePath(pathTmpl, {
-        'account_id': 'code-benjamin-du-monde',
+        'account_id': 'code-benjamin du monde',
         'shipping_address_id': 1234567890
       })
 
-      assert.equal(path, '/sites/subdomain-mysubdomain/accounts/code-benjamin-du-monde/shipping_addresses/1234567890')
+      assert.equal(path, '/sites/subdomain-mysubdomain/accounts/code-benjamin%20du%20monde/shipping_addresses/1234567890')
     })
   })
 })


### PR DESCRIPTION
Trying to use a value which contains unencoded strings for a url parameter throws an error:

```js
const account = await client.getAccount("code-benjamin du monde12")
```

```
Unknown Error:  TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
    at new ClientRequest (_http_client.js:127:13)
```

We need to encode the url paramters.