### PR TITLE
Fix Pager bugs

### DIFF
--- a/lib/recurly/Pager.js
+++ b/lib/recurly/Pager.js
@@ -70,10 +70,16 @@ class Pager {
                 } else {
                   resources = it.value
                   resourceNumber = 0
-                  resolve({
-                    value: resources[0],
-                    done: false
-                  })
+                  // if we have some resources, yield the first
+                  if (resources && resources.length > 0) {
+                    resolve({
+                      value: resources[resourceNumber++],
+                      done: false
+                    })
+                  // if we have some don't stop iteration
+                  } else {
+                    resolve({ done: true })
+                  }
                 }
               })
               .catch(reject)


### PR DESCRIPTION
Checking in on pager edge cases after https://github.com/recurly/recurly-client-net/pull/432 . Found that this pager does not support empty pages and also has a bug which yields the first item in the page twice. I'll be following up with some tests around this Pager that are similar to our other clients.

### Testing

Try enumerating shipping address on an account. If the account has no shipping addresses, nothing should be logged. If it has 1, only 1 should be logged (was yielding it twice).

```js
const acct = await stub.createAccount()
await stub.createShippingAddress(acct)

const addresses = client.listShippingAddresses(accountId, { limit: 200 })
for await (const address of addresses.each()) {
  console.log(address.street1)
}

await client.deactivateAccount(acct.id)
```
