### PR TITLE
Remove the site-id constraint from Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,14 @@ npm install recurly@3.0.0-beta.4 --save-prod
 A client object represents a connection to the Recurly API. The client implements
 each `operation` that can be performed in the API as a method.
 
-To initialize a client, give it an API key and a subdomain:
+To initialize a client, you only need an API key:
 
 ```js
 const recurly = require('recurly')
 // You should store your api key somewhere safe
 // and not in plain text if possible
 const myApiKey = '<myapikey>'
-const mySubdomain = '<mysubdomain>'
-const client = new recurly.Client(myApiKey, `subdomain-${mySubdomain}`)
+const client = new recurly.Client(myApiKey)
 ```
 
 ### Operations

--- a/docs/index.html
+++ b/docs/index.html
@@ -2100,7 +2100,7 @@ prevent some records from being returned.
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>getSite()</span>
+            <span class='code strong strong truncate'>getSite(siteId)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -2111,7 +2111,7 @@ prevent some records from being returned.
   <p>Fetch a site</p>
 <p>API docs: <a href="https://developers.recurly.com/api/v2018-08-09#operation/get_site">https://developers.recurly.com/api/v2018-08-09#operation/get_site</a></p>
 
-    <div class='pre p1 fill-light mt0'>getSite(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#site">Site</a>></div>
+    <div class='pre p1 fill-light mt0'>getSite(siteId: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#site">Site</a>></div>
   
   
 
@@ -2122,6 +2122,24 @@ prevent some records from being returned.
   
   
 
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>siteId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    Site ID or subdomain (use prefix: 
+<code>subdomain-</code>
+, e.g. 
+<code>subdomain-recurly</code>
+).
+
+          </div>
+          
+        </div>
+      
+    </div>
   
 
   

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -33,7 +33,6 @@ class BaseClient {
   }
 
   _interpolatePath (path, parameters = {}) {
-    parameters['site_id'] = this.siteId
     Object.keys(parameters).forEach(name => {
       path = path.replace(`{${name}}`, encodeURIComponent(parameters[name].toString()))
     })

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -66,11 +66,12 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2018-08-09#operation/get_site}
    *
    *
+   * @param {string} siteId - Site ID or subdomain (use prefix: `subdomain-`, e.g. `subdomain-recurly`).
    * @return {Promise<Site>} A site.
    */
-  async getSite () {
+  async getSite (siteId) {
     let path = '/sites/{site_id}'
-    path = this._interpolatePath(path)
+    path = this._interpolatePath(path, { 'site_id': siteId })
     return this._makeRequest('GET', path, null)
   }
 
@@ -118,7 +119,7 @@ class Client extends BaseClient {
    * @return {Pager<Account>} A list of the site's accounts.
    */
   listAccounts (params = {}) {
-    let path = '/sites/{site_id}/accounts'
+    let path = '/accounts'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -160,7 +161,7 @@ class Client extends BaseClient {
    * @return {Promise<Account>} An account.
    */
   async createAccount (body) {
-    let path = '/sites/{site_id}/accounts'
+    let path = '/accounts'
     path = this._interpolatePath(path)
     return this._makeRequest('POST', path, body)
   }
@@ -190,7 +191,7 @@ class Client extends BaseClient {
    * @return {Promise<Account>} An account.
    */
   async getAccount (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}'
+    let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('GET', path, null)
   }
@@ -225,7 +226,7 @@ class Client extends BaseClient {
    * @return {Promise<Account>} An account.
    */
   async updateAccount (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}'
+    let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('PUT', path, body)
   }
@@ -254,7 +255,7 @@ class Client extends BaseClient {
    * @return {Promise<Account>} An account.
    */
   async deactivateAccount (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}'
+    let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -284,7 +285,7 @@ class Client extends BaseClient {
    * @return {Promise<AccountAcquisition>} An account's acquisition data.
    */
   async getAccountAcquisition (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/acquisition'
+    let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('GET', path, null)
   }
@@ -320,7 +321,7 @@ class Client extends BaseClient {
    * @return {Promise<AccountAcquisition>} An account's updated acquisition data.
    */
   async updateAccountAcquisition (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/acquisition'
+    let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('PUT', path, body)
   }
@@ -350,7 +351,7 @@ class Client extends BaseClient {
    * @return {Promise<Empty>} Acquisition data was succesfully deleted.
    */
   async removeAccountAcquisition (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/acquisition'
+    let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -379,7 +380,7 @@ class Client extends BaseClient {
    * @return {Promise<Account>} An account.
    */
   async reactivateAccount (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/reactivate'
+    let path = '/accounts/{account_id}/reactivate'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('PUT', path, null)
   }
@@ -409,7 +410,7 @@ class Client extends BaseClient {
    * @return {Promise<AccountBalance>} An account's balance.
    */
   async getAccountBalance (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/balance'
+    let path = '/accounts/{account_id}/balance'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('GET', path, null)
   }
@@ -439,7 +440,7 @@ class Client extends BaseClient {
    * @return {Promise<BillingInfo>} An account's billing information.
    */
   async getBillingInfo (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/billing_info'
+    let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('GET', path, null)
   }
@@ -474,7 +475,7 @@ class Client extends BaseClient {
    * @return {Promise<BillingInfo>} Updated billing information.
    */
   async updateBillingInfo (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/billing_info'
+    let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('PUT', path, body)
   }
@@ -504,7 +505,7 @@ class Client extends BaseClient {
    * @return {Promise<Empty>} Billing information deleted
    */
   async removeBillingInfo (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/billing_info'
+    let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -542,7 +543,7 @@ class Client extends BaseClient {
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on an account.
    */
   listAccountCouponRedemptions (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/coupon_redemptions'
+    let path = '/accounts/{account_id}/coupon_redemptions'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -572,7 +573,7 @@ class Client extends BaseClient {
    * @return {Promise<CouponRedemption>} An active coupon redemption on an account.
    */
   async getActiveCouponRedemption (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/coupon_redemptions/active'
+    let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('GET', path, null)
   }
@@ -588,7 +589,7 @@ class Client extends BaseClient {
    * @return {Promise<CouponRedemption>} Returns the new coupon redemption.
    */
   async createCouponRedemption (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/coupon_redemptions/active'
+    let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('POST', path, body)
   }
@@ -603,7 +604,7 @@ class Client extends BaseClient {
    * @return {Promise<CouponRedemption>} Coupon redemption deleted.
    */
   async removeCouponRedemption (accountId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/coupon_redemptions/active'
+    let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -637,7 +638,7 @@ class Client extends BaseClient {
    * @return {Pager<CreditPayment>} A list of the account's credit payments.
    */
   listAccountCreditPayments (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/credit_payments'
+    let path = '/accounts/{account_id}/credit_payments'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -683,7 +684,7 @@ class Client extends BaseClient {
    * @return {Pager<Invoice>} A list of the account's invoices.
    */
   listAccountInvoices (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/invoices'
+    let path = '/accounts/{account_id}/invoices'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -720,7 +721,7 @@ class Client extends BaseClient {
    * @return {Promise<InvoiceCollection>} Returns the new invoices.
    */
   async createInvoice (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/invoices'
+    let path = '/accounts/{account_id}/invoices'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('POST', path, body)
   }
@@ -757,7 +758,7 @@ class Client extends BaseClient {
    * @return {Promise<InvoiceCollection>} Returns the invoice previews.
    */
   async previewInvoice (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/invoices/preview'
+    let path = '/accounts/{account_id}/invoices/preview'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('POST', path, body)
   }
@@ -800,7 +801,7 @@ class Client extends BaseClient {
    * @return {Pager<LineItem>} A list of the account's line items.
    */
   listAccountLineItems (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/line_items'
+    let path = '/accounts/{account_id}/line_items'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -836,7 +837,7 @@ class Client extends BaseClient {
    * @return {Promise<LineItem>} Returns the new line item.
    */
   async createLineItem (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/line_items'
+    let path = '/accounts/{account_id}/line_items'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('POST', path, body)
   }
@@ -870,7 +871,7 @@ class Client extends BaseClient {
    * @return {Pager<AccountNote>} A list of an account's notes.
    */
   listAccountNotes (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/notes'
+    let path = '/accounts/{account_id}/notes'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -902,7 +903,7 @@ class Client extends BaseClient {
    * @return {Promise<AccountNote>} An account note.
    */
   async getAccountNote (accountId, accountNoteId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/notes/{account_note_id}'
+    let path = '/accounts/{account_id}/notes/{account_note_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'account_note_id': accountNoteId })
     return this._makeRequest('GET', path, null)
   }
@@ -948,7 +949,7 @@ class Client extends BaseClient {
    * @return {Pager<ShippingAddress>} A list of an account's shipping addresses.
    */
   listShippingAddresses (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/shipping_addresses'
+    let path = '/accounts/{account_id}/shipping_addresses'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -988,7 +989,7 @@ class Client extends BaseClient {
    * @return {Promise<ShippingAddress>} Returns the new shipping address.
    */
   async createShippingAddress (accountId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/shipping_addresses'
+    let path = '/accounts/{account_id}/shipping_addresses'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return this._makeRequest('POST', path, body)
   }
@@ -1019,7 +1020,7 @@ class Client extends BaseClient {
    * @return {Promise<ShippingAddress>} A shipping address.
    */
   async getShippingAddress (accountId, shippingAddressId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
+    let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
     return this._makeRequest('GET', path, null)
   }
@@ -1055,7 +1056,7 @@ class Client extends BaseClient {
    * @return {Promise<ShippingAddress>} The updated shipping address.
    */
   async updateShippingAddress (accountId, shippingAddressId, body) {
-    let path = '/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
+    let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
     return this._makeRequest('PUT', path, body)
   }
@@ -1086,7 +1087,7 @@ class Client extends BaseClient {
    * @return {Promise<Empty>} Shipping address deleted.
    */
   async removeShippingAddress (accountId, shippingAddressId) {
-    let path = '/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
+    let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -1132,7 +1133,7 @@ class Client extends BaseClient {
    * @return {Pager<Subscription>} A list of the account's subscriptions.
    */
   listAccountSubscriptions (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/subscriptions'
+    let path = '/accounts/{account_id}/subscriptions'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -1174,7 +1175,7 @@ class Client extends BaseClient {
    * @return {Pager<Transaction>} A list of the account's transactions.
    */
   listAccountTransactions (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/transactions'
+    let path = '/accounts/{account_id}/transactions'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -1218,7 +1219,7 @@ class Client extends BaseClient {
    * @return {Pager<Account>} A list of an account's child accounts.
    */
   listChildAccounts (accountId, params = {}) {
-    let path = '/sites/{site_id}/accounts/{account_id}/accounts'
+    let path = '/accounts/{account_id}/accounts'
     path = this._interpolatePath(path, { 'account_id': accountId })
     return new Pager(this, path, params)
   }
@@ -1257,7 +1258,7 @@ class Client extends BaseClient {
    * @return {Pager<AccountAcquisition>} A list of the site's account acquisition data.
    */
   listAccountAcquisition (params = {}) {
-    let path = '/sites/{site_id}/acquisitions'
+    let path = '/acquisitions'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -1302,7 +1303,7 @@ class Client extends BaseClient {
    * @return {Pager<Coupon>} A list of the site's coupons.
    */
   listCoupons (params = {}) {
-    let path = '/sites/{site_id}/coupons'
+    let path = '/coupons'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -1317,7 +1318,7 @@ class Client extends BaseClient {
    * @return {Promise<Coupon>} A new coupon.
    */
   async createCoupon (body) {
-    let path = '/sites/{site_id}/coupons'
+    let path = '/coupons'
     path = this._interpolatePath(path)
     return this._makeRequest('POST', path, body)
   }
@@ -1347,7 +1348,7 @@ class Client extends BaseClient {
    * @return {Promise<Coupon>} A coupon.
    */
   async getCoupon (couponId) {
-    let path = '/sites/{site_id}/coupons/{coupon_id}'
+    let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
     return this._makeRequest('GET', path, null)
   }
@@ -1363,7 +1364,7 @@ class Client extends BaseClient {
    * @return {Promise<Coupon>} The updated coupon.
    */
   async updateCoupon (couponId, body) {
-    let path = '/sites/{site_id}/coupons/{coupon_id}'
+    let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
     return this._makeRequest('PUT', path, body)
   }
@@ -1403,7 +1404,7 @@ class Client extends BaseClient {
    * @return {Pager<UniqueCouponCode>} A list of unique coupon codes that were generated
    */
   listUniqueCouponCodes (couponId, params = {}) {
-    let path = '/sites/{site_id}/coupons/{coupon_id}/unique_coupon_codes'
+    let path = '/coupons/{coupon_id}/unique_coupon_codes'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
     return new Pager(this, path, params)
   }
@@ -1436,7 +1437,7 @@ class Client extends BaseClient {
    * @return {Pager<CreditPayment>} A list of the site's credit payments.
    */
   listCreditPayments (params = {}) {
-    let path = '/sites/{site_id}/credit_payments'
+    let path = '/credit_payments'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -1451,7 +1452,7 @@ class Client extends BaseClient {
    * @return {Promise<CreditPayment>} A credit payment.
    */
   async getCreditPayment (creditPaymentId) {
-    let path = '/sites/{site_id}/credit_payments/{credit_payment_id}'
+    let path = '/credit_payments/{credit_payment_id}'
     path = this._interpolatePath(path, { 'credit_payment_id': creditPaymentId })
     return this._makeRequest('GET', path, null)
   }
@@ -1496,7 +1497,7 @@ class Client extends BaseClient {
    * @return {Pager<CustomFieldDefinition>} A list of the site's custom field definitions.
    */
   listCustomFieldDefinitions (params = {}) {
-    let path = '/sites/{site_id}/custom_field_definitions'
+    let path = '/custom_field_definitions'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -1526,7 +1527,7 @@ class Client extends BaseClient {
    * @return {Promise<CustomFieldDefinition>} An custom field definition.
    */
   async getCustomFieldDefinition (customFieldDefinitionId) {
-    let path = '/sites/{site_id}/custom_field_definitions/{custom_field_definition_id}'
+    let path = '/custom_field_definitions/{custom_field_definition_id}'
     path = this._interpolatePath(path, { 'custom_field_definition_id': customFieldDefinitionId })
     return this._makeRequest('GET', path, null)
   }
@@ -1577,7 +1578,7 @@ class Client extends BaseClient {
    * @return {Pager<Invoice>} A list of the site's invoices.
    */
   listInvoices (params = {}) {
-    let path = '/sites/{site_id}/invoices'
+    let path = '/invoices'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -1607,7 +1608,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} An invoice.
    */
   async getInvoice (invoiceId) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}'
+    let path = '/invoices/{invoice_id}'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('GET', path, null)
   }
@@ -1644,7 +1645,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} An invoice.
    */
   async putInvoice (invoiceId, body) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}'
+    let path = '/invoices/{invoice_id}'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('PUT', path, body)
   }
@@ -1674,7 +1675,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} The updated invoice.
    */
   async collectInvoice (invoiceId) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/collect'
+    let path = '/invoices/{invoice_id}/collect'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('PUT', path, null)
   }
@@ -1704,7 +1705,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} The updated invoice.
    */
   async failInvoice (invoiceId) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/mark_failed'
+    let path = '/invoices/{invoice_id}/mark_failed'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('PUT', path, null)
   }
@@ -1735,7 +1736,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} The updated invoice.
    */
   async markInvoiceSuccessful (invoiceId) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/mark_successful'
+    let path = '/invoices/{invoice_id}/mark_successful'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('PUT', path, null)
   }
@@ -1765,7 +1766,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} The updated invoice.
    */
   async reopenInvoice (invoiceId) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/reopen'
+    let path = '/invoices/{invoice_id}/reopen'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('PUT', path, null)
   }
@@ -1808,7 +1809,7 @@ class Client extends BaseClient {
    * @return {Pager<LineItem>} A list of the invoice's line items.
    */
   listInvoiceLineItems (invoiceId, params = {}) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/line_items'
+    let path = '/invoices/{invoice_id}/line_items'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return new Pager(this, path, params)
   }
@@ -1846,7 +1847,7 @@ class Client extends BaseClient {
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions associated with the invoice.
    */
   listInvoiceCouponRedemptions (invoiceId, params = {}) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/coupon_redemptions'
+    let path = '/invoices/{invoice_id}/coupon_redemptions'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return new Pager(this, path, params)
   }
@@ -1867,7 +1868,7 @@ class Client extends BaseClient {
    * @return {Pager<Invoice>} A list of the credit or charge invoices associated with the invoice.
    */
   listRelatedInvoices (invoiceId, params = {}) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/related_invoices'
+    let path = '/invoices/{invoice_id}/related_invoices'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return new Pager(this, path, params)
   }
@@ -1905,7 +1906,7 @@ class Client extends BaseClient {
    * @return {Promise<Invoice>} Returns the new credit invoice.
    */
   async refundInvoice (invoiceId, body) {
-    let path = '/sites/{site_id}/invoices/{invoice_id}/refund'
+    let path = '/invoices/{invoice_id}/refund'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
     return this._makeRequest('POST', path, body)
   }
@@ -1953,7 +1954,7 @@ class Client extends BaseClient {
    * @return {Pager<LineItem>} A list of the site's line items.
    */
   listLineItems (params = {}) {
-    let path = '/sites/{site_id}/line_items'
+    let path = '/line_items'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -1983,7 +1984,7 @@ class Client extends BaseClient {
    * @return {Promise<LineItem>} A line item.
    */
   async getLineItem (lineItemId) {
-    let path = '/sites/{site_id}/line_items/{line_item_id}'
+    let path = '/line_items/{line_item_id}'
     path = this._interpolatePath(path, { 'line_item_id': lineItemId })
     return this._makeRequest('GET', path, null)
   }
@@ -2013,7 +2014,7 @@ class Client extends BaseClient {
    * @return {Promise<Empty>} Line item deleted.
    */
   async removeLineItem (lineItemId) {
-    let path = '/sites/{site_id}/line_items/{line_item_id}'
+    let path = '/line_items/{line_item_id}'
     path = this._interpolatePath(path, { 'line_item_id': lineItemId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -2059,7 +2060,7 @@ class Client extends BaseClient {
    * @return {Pager<Plan>} A list of plans.
    */
   listPlans (params = {}) {
-    let path = '/sites/{site_id}/plans'
+    let path = '/plans'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -2099,7 +2100,7 @@ class Client extends BaseClient {
    * @return {Promise<Plan>} A plan.
    */
   async createPlan (body) {
-    let path = '/sites/{site_id}/plans'
+    let path = '/plans'
     path = this._interpolatePath(path)
     return this._makeRequest('POST', path, body)
   }
@@ -2129,7 +2130,7 @@ class Client extends BaseClient {
    * @return {Promise<Plan>} A plan.
    */
   async getPlan (planId) {
-    let path = '/sites/{site_id}/plans/{plan_id}'
+    let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
     return this._makeRequest('GET', path, null)
   }
@@ -2163,7 +2164,7 @@ class Client extends BaseClient {
    * @return {Promise<Plan>} A plan.
    */
   async updatePlan (planId, body) {
-    let path = '/sites/{site_id}/plans/{plan_id}'
+    let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
     return this._makeRequest('PUT', path, body)
   }
@@ -2193,7 +2194,7 @@ class Client extends BaseClient {
    * @return {Promise<Plan>} Plan deleted
    */
   async removePlan (planId) {
-    let path = '/sites/{site_id}/plans/{plan_id}'
+    let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -2234,7 +2235,7 @@ class Client extends BaseClient {
    * @return {Pager<AddOn>} A list of add-ons.
    */
   listPlanAddOns (planId, params = {}) {
-    let path = '/sites/{site_id}/plans/{plan_id}/add_ons'
+    let path = '/plans/{plan_id}/add_ons'
     path = this._interpolatePath(path, { 'plan_id': planId })
     return new Pager(this, path, params)
   }
@@ -2250,7 +2251,7 @@ class Client extends BaseClient {
    * @return {Promise<AddOn>} An add-on.
    */
   async createPlanAddOn (planId, body) {
-    let path = '/sites/{site_id}/plans/{plan_id}/add_ons'
+    let path = '/plans/{plan_id}/add_ons'
     path = this._interpolatePath(path, { 'plan_id': planId })
     return this._makeRequest('POST', path, body)
   }
@@ -2266,7 +2267,7 @@ class Client extends BaseClient {
    * @return {Promise<AddOn>} An add-on.
    */
   async getPlanAddOn (planId, addOnId) {
-    let path = '/sites/{site_id}/plans/{plan_id}/add_ons/{add_on_id}'
+    let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
     return this._makeRequest('GET', path, null)
   }
@@ -2283,7 +2284,7 @@ class Client extends BaseClient {
    * @return {Promise<AddOn>} An add-on.
    */
   async updatePlanAddOn (planId, addOnId, body) {
-    let path = '/sites/{site_id}/plans/{plan_id}/add_ons/{add_on_id}'
+    let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
     return this._makeRequest('PUT', path, body)
   }
@@ -2299,7 +2300,7 @@ class Client extends BaseClient {
    * @return {Promise<AddOn>} Add-on deleted
    */
   async removePlanAddOn (planId, addOnId) {
-    let path = '/sites/{site_id}/plans/{plan_id}/add_ons/{add_on_id}'
+    let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -2339,7 +2340,7 @@ class Client extends BaseClient {
    * @return {Pager<AddOn>} A list of add-ons.
    */
   listAddOns (params = {}) {
-    let path = '/sites/{site_id}/add_ons'
+    let path = '/add_ons'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -2354,7 +2355,7 @@ class Client extends BaseClient {
    * @return {Promise<AddOn>} An add-on.
    */
   async getAddOn (addOnId) {
-    let path = '/sites/{site_id}/add_ons/{add_on_id}'
+    let path = '/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'add_on_id': addOnId })
     return this._makeRequest('GET', path, null)
   }
@@ -2405,7 +2406,7 @@ class Client extends BaseClient {
    * @return {Pager<Subscription>} A list of the site's subscriptions.
    */
   listSubscriptions (params = {}) {
-    let path = '/sites/{site_id}/subscriptions'
+    let path = '/subscriptions'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -2442,7 +2443,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} A subscription.
    */
   async createSubscription (body) {
-    let path = '/sites/{site_id}/subscriptions'
+    let path = '/subscriptions'
     path = this._interpolatePath(path)
     return this._makeRequest('POST', path, body)
   }
@@ -2472,7 +2473,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} A subscription.
    */
   async getSubscription (subscriptionId) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}'
+    let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('GET', path, null)
   }
@@ -2508,7 +2509,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} A subscription.
    */
   async modifySubscription (subscriptionId, body) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}'
+    let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('PUT', path, body)
   }
@@ -2549,7 +2550,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} An expired subscription.
    */
   async terminateSubscription (subscriptionId, params = {}) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}'
+    let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -2579,7 +2580,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} A canceled or failed subscription.
    */
   async cancelSubscription (subscriptionId) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/cancel'
+    let path = '/subscriptions/{subscription_id}/cancel'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('PUT', path, null)
   }
@@ -2610,7 +2611,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} An active subscription.
    */
   async reactivateSubscription (subscriptionId) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/reactivate'
+    let path = '/subscriptions/{subscription_id}/reactivate'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('PUT', path, null)
   }
@@ -2626,7 +2627,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} A subscription.
    */
   async pauseSubscription (subscriptionId, body) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/pause'
+    let path = '/subscriptions/{subscription_id}/pause'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('PUT', path, body)
   }
@@ -2641,7 +2642,7 @@ class Client extends BaseClient {
    * @return {Promise<Subscription>} A subscription.
    */
   async resumeSubscription (subscriptionId) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/resume'
+    let path = '/subscriptions/{subscription_id}/resume'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('PUT', path, null)
   }
@@ -2671,7 +2672,7 @@ class Client extends BaseClient {
    * @return {Promise<SubscriptionChange>} A subscription's pending change.
    */
   async getSubscriptionChange (subscriptionId) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/change'
+    let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('GET', path, null)
   }
@@ -2707,7 +2708,7 @@ class Client extends BaseClient {
    * @return {Promise<SubscriptionChange>} A subscription change.
    */
   async createSubscriptionChange (subscriptionId, body) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/change'
+    let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('POST', path, body)
   }
@@ -2737,7 +2738,7 @@ class Client extends BaseClient {
    * @return {Promise<Empty>} Subscription change was deleted.
    */
   async removeSubscriptionChange (subscriptionId) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/change'
+    let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -2783,7 +2784,7 @@ class Client extends BaseClient {
    * @return {Pager<Invoice>} A list of the subscription's invoices.
    */
   listSubscriptionInvoices (subscriptionId, params = {}) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/invoices'
+    let path = '/subscriptions/{subscription_id}/invoices'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return new Pager(this, path, params)
   }
@@ -2826,7 +2827,7 @@ class Client extends BaseClient {
    * @return {Pager<LineItem>} A list of the subscription's line items.
    */
   listSubscriptionLineItems (subscriptionId, params = {}) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/line_items'
+    let path = '/subscriptions/{subscription_id}/line_items'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return new Pager(this, path, params)
   }
@@ -2864,7 +2865,7 @@ class Client extends BaseClient {
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on a subscription.
    */
   listSubscriptionCouponRedemptions (subscriptionId, params = {}) {
-    let path = '/sites/{site_id}/subscriptions/{subscription_id}/coupon_redemptions'
+    let path = '/subscriptions/{subscription_id}/coupon_redemptions'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
     return new Pager(this, path, params)
   }
@@ -2911,7 +2912,7 @@ class Client extends BaseClient {
    * @return {Pager<Transaction>} A list of the site's transactions.
    */
   listTransactions (params = {}) {
-    let path = '/sites/{site_id}/transactions'
+    let path = '/transactions'
     path = this._interpolatePath(path)
     return new Pager(this, path, params)
   }
@@ -2941,7 +2942,7 @@ class Client extends BaseClient {
    * @return {Promise<Transaction>} A transaction.
    */
   async getTransaction (transactionId) {
-    let path = '/sites/{site_id}/transactions/{transaction_id}'
+    let path = '/transactions/{transaction_id}'
     path = this._interpolatePath(path, { 'transaction_id': transactionId })
     return this._makeRequest('GET', path, null)
   }
@@ -2956,7 +2957,7 @@ class Client extends BaseClient {
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
   async getUniqueCouponCode (uniqueCouponCodeId) {
-    let path = '/sites/{site_id}/unique_coupon_codes/{unique_coupon_code_id}'
+    let path = '/unique_coupon_codes/{unique_coupon_code_id}'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
     return this._makeRequest('GET', path, null)
   }
@@ -2971,7 +2972,7 @@ class Client extends BaseClient {
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
   async deactivateUniqueCouponCode (uniqueCouponCodeId) {
-    let path = '/sites/{site_id}/unique_coupon_codes/{unique_coupon_code_id}'
+    let path = '/unique_coupon_codes/{unique_coupon_code_id}'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
     return this._makeRequest('DELETE', path, null)
   }
@@ -2986,7 +2987,7 @@ class Client extends BaseClient {
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
   async reactivateUniqueCouponCode (uniqueCouponCodeId) {
-    let path = '/sites/{site_id}/unique_coupon_codes/{unique_coupon_code_id}/restore'
+    let path = '/unique_coupon_codes/{unique_coupon_code_id}/restore'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
     return this._makeRequest('PUT', path, null)
   }
@@ -3031,7 +3032,7 @@ class Client extends BaseClient {
    * @return {Promise<InvoiceCollection>} Returns the new invoices
    */
   async createPurchase (body) {
-    let path = '/sites/{site_id}/purchases'
+    let path = '/purchases'
     path = this._interpolatePath(path)
     return this._makeRequest('POST', path, body)
   }
@@ -3076,7 +3077,7 @@ class Client extends BaseClient {
    * @return {Promise<InvoiceCollection>} Returns preview of the new invoices
    */
   async previewPurchase (body) {
-    let path = '/sites/{site_id}/purchases/preview'
+    let path = '/purchases/preview'
     path = this._interpolatePath(path)
     return this._makeRequest('POST', path, body)
   }

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 npm install
 ./node_modules/.bin/documentation build lib/**  --format html --output docs

--- a/scripts/format
+++ b/scripts/format
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+set -e
 
 ./node_modules/.bin/standard --fix "lib/**/*.js" "test/**/*.js"

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [ "$1" = "--watch" ]; then
   ./node_modules/.bin/mocha --recursive --watch

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -24,13 +24,13 @@ describe('BaseClient', () => {
   })
   describe('#_interpolatePath', () => {
     it('Should interpolate the path with the given params', () => {
-      const pathTmpl = '/sites/{site_id}/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
+      const pathTmpl = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
       const path = client._interpolatePath(pathTmpl, {
         'account_id': 'code-benjamin du monde',
         'shipping_address_id': 1234567890
       })
 
-      assert.equal(path, '/sites/subdomain-mysubdomain/accounts/code-benjamin%20du%20monde/shipping_addresses/1234567890')
+      assert.equal(path, '/accounts/code-benjamin%20du%20monde/shipping_addresses/1234567890')
     })
   })
 })


### PR DESCRIPTION
This removes the constraint of required site-id to initialize a client.
The site can be inferred from the api key. We will be adding ways to
use multiple sites with the same client in the future. This sets us
up so we can do that in a non-breaking way.