### PR TITLE
Remove the site-id parameter in client constructor

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -13,12 +13,9 @@ const { Request, Response } = require('./Http')
  * This is the base functionality for the Recurly.Client.
  * @private
  * @param {string} apiKey - The private api key for the site.
- * @param {string} siteId - The site id (if you only have the subdomain, use the subdomain- prefix: `subdomain-${mySubdomain}`).
  */
 class BaseClient {
-  constructor (apiKey, siteId) {
-    this.siteId = siteId
-
+  constructor (apiKey) {
     // API key should not be instance variable.
     // This way it's not accidentally logged.
     this._getApiKey = () => apiKey

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -11,12 +11,11 @@ class TestClient extends BaseClient {
   }
 }
 
-const client = new TestClient('myapikey', 'subdomain-mysubdomain')
+const client = new TestClient('myapikey')
 
 describe('BaseClient', () => {
   describe('#constructor', () => {
     it('Should set the internal state and headers', () => {
-      assert.equal(client.siteId, 'subdomain-mysubdomain')
       assert.equal(client._getDefaultOptions().headers['Authorization'], 'Basic bXlhcGlrZXk6')
       assert.equal(client._getDefaultOptions().headers['User-Agent'], `Recurly/${pkg.version}; node`)
       assert.equal(client._getDefaultOptions().headers['Accept'], 'application/vnd.recurly.v2020-01-01')


### PR DESCRIPTION
Following up on https://github.com/recurly/recurly-client-node/pull/33

This is not really supported anymore and could be confusing so we're
removing it.