### PR TITLE
Release 3.0.0-beta.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,9 @@
 [bumpversion]
-current_version = 3.0.0-beta.4
+current_version = 3.0.0-beta.5
 parse = (?P<major>\d+)
-        \.(?P<minor>\d+)
-        \.(?P<patch>\d+)
-        (\-(?P<release>[a-z]+)\.(?P<build>\d+))?
-
+	\.(?P<minor>\d+)
+	\.(?P<patch>\d+)
+	(\-(?P<release>[a-z]+)\.(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}.{build}
 	{major}.{minor}.{patch}
@@ -18,3 +17,4 @@ values =
 [bumpversion:file:package.json]
 
 [bumpversion:file:README.md]
+

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We recommend manually inserting the dependency into the `dependencies` section o
 ```
 {
   // ...
-  "recurly" : "3.0.0-beta.4"
+  "recurly" : "3.0.0-beta.5"
   // ...
 }
 ```
@@ -29,7 +29,7 @@ We recommend manually inserting the dependency into the `dependencies` section o
 
 Install via the command line:
 ```
-npm install recurly@3.0.0-beta.4 --save-prod
+npm install recurly@3.0.0-beta.5 --save-prod
 ```
 
 ### Creating a client

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "Recurly V3 node client",
   "main": "lib/recurly.js",
   "scripts": {


### PR DESCRIPTION
- Implement bump script https://github.com/recurly/recurly-client-node/pull/34
- Add section in README for err handling https://github.com/recurly/recurly-client-node/pull/35
- Remove site id constraint in Client constructor https://github.com/recurly/recurly-client-node/pull/39
- Remove site id constraint https://github.com/recurly/recurly-client-node/pull/33

### Upgrade Notes

Technically not a breaking changes, but clients constructors no longer
use the site id. The site will be inferred from the key:

```js

// change your constructors
const client = new recurly.Client(apiKey, siteId);

// to only pass in api key
const client = new recurly.Client(apiKey);
```