### PR TITLE
Do not ever allow runtime deps in this library

### DIFF
--- a/test/recurly.test.js
+++ b/test/recurly.test.js
@@ -4,8 +4,41 @@ const assert = require('assert').strict
 const recurly = require('../lib/recurly')
 const Client = require('../lib/recurly/Client')
 const Account = require('../lib/recurly/resources/Account')
+const pkg = require('../package.json')
 
 describe('recurly', () => {
+  describe('Dependencies', () => {
+    it('Should have no runtime dependencies', () => {
+      const msg = `
+        We do not allow adding runtime dependencies to this
+        library for security and maintainability reasons.
+        The "dependencies" key in package.json should be
+        an empty object
+      `
+      let numDeps = Object.keys(pkg.dependencies || {}).length
+      assert.equal(numDeps, 0, msg)
+    })
+    it('Should have no peer dependencies', () => {
+      const msg = `
+        We do not allow adding runtime dependencies to this
+        library for security and maintainability reasons.
+        The "peerDependencies" key in package.json should be
+        an empty object
+      `
+      let numDeps = Object.keys(pkg.peerDependencies || {}).length
+      assert.equal(numDeps, 0, msg)
+    })
+    it('Should have no optional dependencies', () => {
+      const msg = `
+        We do not allow adding runtime dependencies to this
+        library for security and maintainability reasons.
+        The "optionalDependencies" key in package.json should be
+        an empty object
+      `
+      let numDeps = Object.keys(pkg.optionalDependencies || {}).length
+      assert.equal(numDeps, 0, msg)
+    })
+  })
   describe('#Client', () => {
     it('Should expose the Client in the top level module', () => {
       assert.equal(recurly.Client, Client)


### PR DESCRIPTION
To test, you can try adding a runtime dep to package.json and running `script/test`. It will fail the tests.