### PR TITLE
Pick error class for responses without bodies

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -64,14 +64,9 @@ class BaseClient {
 
           const recurlyRequest = new Request(method, path, requestBody)
           const recurlyResponse = new Response(httpResponse, rbody, recurlyRequest)
+          const err = this._errorFromResponse(recurlyResponse)
 
-          if (recurlyResponse.status < 200 || recurlyResponse.status > 299) {
-            const errBody = recurlyResponse.body.error
-            let className = utils.classify(errBody.type)
-            if (!className.endsWith('Error')) className += 'Error'
-            const ErrClass = apiErrors[className] || ApiError
-            const err = new ErrClass(errBody.message, errBody.type, errBody.params)
-            err._setResponse(recurlyResponse)
+          if (err) {
             reject(err)
           } else {
             const resource = casters.castResponse(recurlyResponse.body)
@@ -105,6 +100,47 @@ class BaseClient {
     }
 
     return options
+  }
+
+  /**
+   * @param {Response} resp
+   * @return {(ApiError|null)}
+   */
+  _errorFromResponse (resp) {
+    if (resp.status < 200 || resp.status > 299) {
+      const errBody = resp.body && resp.body.error
+      // If we have a body, we determine the error based on
+      // the contents of the body
+      if (errBody) {
+        let className = utils.classify(errBody.type)
+        if (!className.endsWith('Error')) className += 'Error'
+        const ErrClass = apiErrors[className] || ApiError
+        const err = new ErrClass(errBody.message, errBody.type, errBody.params)
+        err._setResponse(resp)
+        return err
+      // if we don't have a body, we determine the error
+      // based on the http status code
+      } else {
+        let err = new ApiError('Unknown Error', 'unknown')
+
+        if (resp.status === 400) {
+          err = new apiErrors.BadRequestError('Bad Request', 'bad_request')
+        } else if (resp.status >= 401 && resp.status <= 403) {
+          err = new apiErrors.UnauthorizedError('Request not authorized. Perhaps your API key or site-id is incorrect?', 'unauthorized')
+        } else if (resp.status === 404) {
+          err = new apiErrors.NotFoundError('Resource Not Found', 'not_found')
+        } else if (resp.status === 422) {
+          err = new apiErrors.ValidationError('Request not valid', 'validation')
+        } else if (resp.status === 500) {
+          err = new apiErrors.InternalServerError('Recurly Server Error', 'internal_server_error')
+        }
+
+        err._setResponse(resp)
+        return err
+      }
+    }
+
+    return null
   }
 }
 


### PR DESCRIPTION
Resolves #51

The client uses the body to delegate which error class to use. But `HEAD` requests do not return with bodies. This ensures there is a fallback procedure to pick an error class. I think this has opened up a deeper question about how we organize and handle errors and we will address this in the next version.