### PR TITLE
Attempt to parse error response body, Return documented TransactionError resource

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -107,10 +107,21 @@ class BaseClient {
     let err = null
 
     if (resp.status < 200 || resp.status > 299) {
-      const errBody = resp.body && resp.body.error
+      let errBody
+      try {
+        errBody = JSON.parse(resp.body).error
+      } catch (_) {}
+
       // If we have a body, we determine the error based on
       // the contents of the body
       if (errBody) {
+        if (errBody.type === 'transaction') {
+          const resource = casters.castJsonResponse(errBody.transaction_error)
+          err = new apiErrors
+            .TransactionError(errBody.message, errBody.type, errBody.params, resource)
+          err._setResponse(resp)
+          return err
+        }
         let className = utils.classify(errBody.type)
         if (!className.endsWith('Error')) className += 'Error'
         const ErrClass = apiErrors[className] || ApiError

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -107,10 +107,7 @@ class BaseClient {
     let err = null
 
     if (resp.status < 200 || resp.status > 299) {
-      let errBody
-      try {
-        errBody = JSON.parse(resp.body).error
-      } catch (_) {}
+      const errBody = resp.body && JSON.parse(resp.body).error
 
       // If we have a body, we determine the error based on
       // the contents of the body

--- a/lib/recurly/Caster.js
+++ b/lib/recurly/Caster.js
@@ -32,7 +32,7 @@ function castJsonResponse (obj) {
     parsedObj = null
     name = 'Empty'
   } else {
-    parsedObj = JSON.parse(obj)
+    parsedObj = typeof obj === 'string' ? JSON.parse(obj) : obj
     name = utils.className(parsedObj.object)
   }
 

--- a/lib/recurly/api_errors.js
+++ b/lib/recurly/api_errors.js
@@ -29,7 +29,17 @@ class NotFoundError extends ApiError { }
 
 class SimultaneousRequestError extends ApiError { }
 
-class TransactionError extends ApiError { }
+class TransactionError extends ApiError {
+  constructor (message, type, params, transactionErrorResource) {
+    super(message, type, params)
+    this.category = transactionErrorResource.category
+    this.code = transactionErrorResource.code
+    this.merchantAdvice = transactionErrorResource.merchantAdvice
+    this.message = transactionErrorResource.message
+    this.threeDSecureActionTokenId = transactionErrorResource.threeDSecureActionTokenId
+    this.transactionId = transactionErrorResource.transactionId
+  }
+}
 
 class UnauthorizedError extends ApiError { }
 


### PR DESCRIPTION
I noticed a transaction error returned from the api wasn't rejecting with the actual documented [TransactionError](https://recurly.github.io/recurly-client-node/#transactionerror) resource. Then I noticed that the error body wasn't being parsed, meaning it would never create the specific error class, rather would always return a generic `ApiError`.

This fixes both issues, but would welcome feedback on it. It feels a little hacky to me to add extra if branches for a very specific case, but I wasn't sure how else to do it.