### PR TITLE
Failure to parse transaction error

### DIFF
--- a/lib/recurly/ApiError.js
+++ b/lib/recurly/ApiError.js
@@ -1,9 +1,11 @@
 class ApiError extends Error {
-  constructor (message, type, params) {
+  constructor (message, type, attributes = {}) {
     super(message)
     this.name = `Recurly${this.constructor.name}`
     this.type = type
-    this.params = params || []
+    Object.keys(attributes).forEach(k => {
+      this[k] = attributes[k]
+    })
   }
 
   getResponse () {

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -7,6 +7,7 @@ const casters = require('./Caster')
 const querystring = require('querystring')
 const apiErrors = require('./api_errors')
 const utils = require('./utils')
+const resources = require('./resources')
 const { makeRequest } = require('./Http')
 
 const BINARY_TYPES = [
@@ -107,14 +108,22 @@ class BaseClient {
     let err = null
 
     if (resp.status < 200 || resp.status > 299) {
-      const errBody = resp.body && resp.body.error
+      const errBody = resp.body && JSON.parse(resp.body).error
       // If we have a body, we determine the error based on
       // the contents of the body
       if (errBody) {
         let className = utils.classify(errBody.type)
         if (!className.endsWith('Error')) className += 'Error'
         const ErrClass = apiErrors[className] || ApiError
-        err = new ErrClass(errBody.message, errBody.type, errBody.params)
+        if (ErrClass === apiErrors.TransactionError) {
+          err = new ErrClass(errBody.message, errBody.type, {
+            transactionError: resources.TransactionError.cast(errBody.transaction_error)
+          })
+        } else {
+          err = new ErrClass(errBody.message, errBody.type, {
+            params: errBody.params || []
+          })
+        }
         err._setResponse(resp)
         return err
       // if we don't have a body, we determine the error

--- a/test/recurly/ApiError.test.js
+++ b/test/recurly/ApiError.test.js
@@ -7,7 +7,7 @@ const ApiError = require('../../lib/recurly/ApiError')
 describe('ApiError', () => {
   describe('#constructor', () => {
     it('Should set the internal state', () => {
-      const err = new ApiError('my err msg', 'validation', [{ param: 'code' }])
+      const err = new ApiError('my err msg', 'validation', { params: [{ param: 'code' }] })
       assert.equal(err.name, 'RecurlyApiError')
       assert.equal(err.type, 'validation')
       assert.deepEqual(err.params, [{ param: 'code' }])

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -43,7 +43,7 @@ describe('BaseClient', () => {
           resp.body = JSON.stringify({ id: 'myid', object: 'my_resource' })
         } else {
           resp.status = 404
-          resp.body = { error: { type: 'not_found' } }
+          resp.body = JSON.stringify({ error: { type: 'not_found' } })
         }
         return Promise.resolve(resp)
       })


### PR DESCRIPTION
Work in progress for now.

https://github.com/recurly/recurly-client-node/pull/63

In the change of Response#body to a string seems, it seems we missed
some cases in the error handling code. We also want to make sure
TransactionErrors have a special case for their different bodies.