### PR TITLE
Changelog generation and npm audit

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,5 @@
+unreleased=false
+since-tag=3.0.0-beta.2
+exclude-labels=question,bug?,duplicate
+issues-wo-labels=false
+verbose=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Change Log
+
+## [3.2.0](https://github.com/recurly/recurly-client-node/tree/3.2.0) (2019-12-03)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.1.1...3.2.0)
+
+**Merged pull requests:**
+
+- Release 3.2.0 [\#66](https://github.com/recurly/recurly-client-node/pull/66) ([bhelx](https://github.com/bhelx))
+- Allow object attributes [\#65](https://github.com/recurly/recurly-client-node/pull/65) ([bhelx](https://github.com/bhelx))
+- Failure to parse transaction error [\#64](https://github.com/recurly/recurly-client-node/pull/64) ([bhelx](https://github.com/bhelx))
+
+## [3.1.1](https://github.com/recurly/recurly-client-node/tree/3.1.1) (2019-11-22)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.1.0...3.1.1)
+
+**Fixed bugs:**
+
+- Release 3.1.1 \(Bug fix for TypeError in responseEncoding function\) [\#62](https://github.com/recurly/recurly-client-node/pull/62) ([douglasmiller](https://github.com/douglasmiller))
+
+## [3.1.0](https://github.com/recurly/recurly-client-node/tree/3.1.0) (2019-11-18)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.0.1...3.1.0)
+
+**Implemented enhancements:**
+
+- Generated Updates for API version v2019-10-10 [\#60](https://github.com/recurly/recurly-client-node/pull/60) ([douglasmiller](https://github.com/douglasmiller))
+- Generated Updates for API version v2019-10-10 [\#59](https://github.com/recurly/recurly-client-node/pull/59) ([bhelx](https://github.com/bhelx))
+- Anchor links in docs [\#58](https://github.com/recurly/recurly-client-node/pull/58) ([bhelx](https://github.com/bhelx))
+- package.json needs repository key [\#56](https://github.com/recurly/recurly-client-node/pull/56) ([bhelx](https://github.com/bhelx))
+- More test coverage [\#55](https://github.com/recurly/recurly-client-node/pull/55) ([bhelx](https://github.com/bhelx))
+
+**Fixed bugs:**
+
+- TypeError: Cannot read property 'error' of null [\#51](https://github.com/recurly/recurly-client-node/issues/51)
+
+**Merged pull requests:**
+
+- Release 3.1.0 [\#61](https://github.com/recurly/recurly-client-node/pull/61) ([bhelx](https://github.com/bhelx))
+- Pick error class for responses without bodies [\#54](https://github.com/recurly/recurly-client-node/pull/54) ([bhelx](https://github.com/bhelx))
+- Bump eslint-utils from 1.3.1 to 1.4.3 [\#52](https://github.com/recurly/recurly-client-node/pull/52) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [3.0.1](https://github.com/recurly/recurly-client-node/tree/3.0.1) (2019-10-19)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.0.0...3.0.1)
+
+**Fixed bugs:**
+
+- Cannot find module '../../package' from 'BaseClient.js' [\#49](https://github.com/recurly/recurly-client-node/issues/49)
+
+**Merged pull requests:**
+
+- Fix Improper import [\#50](https://github.com/recurly/recurly-client-node/pull/50) ([bhelx](https://github.com/bhelx))
+
+## [3.0.0](https://github.com/recurly/recurly-client-node/tree/3.0.0) (2019-10-08)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.0.0-beta.5...3.0.0)
+
+**Implemented enhancements:**
+
+- Do not ever allow runtime deps in this library [\#45](https://github.com/recurly/recurly-client-node/pull/45) ([bhelx](https://github.com/bhelx))
+- Improve docs with new theme and getting started [\#43](https://github.com/recurly/recurly-client-node/pull/43) ([bhelx](https://github.com/bhelx))
+- Upgrade API version v2019-10-10 [\#42](https://github.com/recurly/recurly-client-node/pull/42) ([bhelx](https://github.com/bhelx))
+- Add a script for releasing [\#41](https://github.com/recurly/recurly-client-node/pull/41) ([bhelx](https://github.com/bhelx))
+- Change base url to v3.recurly.com [\#36](https://github.com/recurly/recurly-client-node/pull/36) ([bhelx](https://github.com/bhelx))
+
+**Merged pull requests:**
+
+- Release 3.0.0 [\#44](https://github.com/recurly/recurly-client-node/pull/44) ([bhelx](https://github.com/bhelx))
+
+## [3.0.0-beta.5](https://github.com/recurly/recurly-client-node/tree/3.0.0-beta.5) (2019-10-01)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.0.0-beta.3...3.0.0-beta.5)
+
+**Implemented enhancements:**
+
+- Remove the site-id parameter in client constructor [\#39](https://github.com/recurly/recurly-client-node/pull/39) ([bhelx](https://github.com/bhelx))
+- Add section for err handling [\#35](https://github.com/recurly/recurly-client-node/pull/35) ([bhelx](https://github.com/bhelx))
+- Implement bump script [\#34](https://github.com/recurly/recurly-client-node/pull/34) ([bhelx](https://github.com/bhelx))
+- Remove the site-id constraint from Client [\#33](https://github.com/recurly/recurly-client-node/pull/33) ([bhelx](https://github.com/bhelx))
+- Update some typos in the readme [\#31](https://github.com/recurly/recurly-client-node/pull/31) ([rafdizzle86](https://github.com/rafdizzle86))
+- Document use of webhooks [\#28](https://github.com/recurly/recurly-client-node/pull/28) ([bhelx](https://github.com/bhelx))
+- Latest v2018-08-09 updates [\#27](https://github.com/recurly/recurly-client-node/pull/27) ([bhelx](https://github.com/bhelx))
+- Expose Request and Response metadata [\#26](https://github.com/recurly/recurly-client-node/pull/26) ([bhelx](https://github.com/bhelx))
+- Implement count and first methods [\#25](https://github.com/recurly/recurly-client-node/pull/25) ([bhelx](https://github.com/bhelx))
+- Add CONTRIBUTING.md [\#23](https://github.com/recurly/recurly-client-node/pull/23) ([bhelx](https://github.com/bhelx))
+- Bump 3.0.0-beta.4 [\#22](https://github.com/recurly/recurly-client-node/pull/22) ([bhelx](https://github.com/bhelx))
+- Latest v2018-08-09 updates [\#21](https://github.com/recurly/recurly-client-node/pull/21) ([bhelx](https://github.com/bhelx))
+- Fix castRequest for arrays [\#20](https://github.com/recurly/recurly-client-node/pull/20) ([bhelx](https://github.com/bhelx))
+
+**Fixed bugs:**
+
+- Bad cast when building request [\#19](https://github.com/recurly/recurly-client-node/issues/19)
+- Fix Pager bugs [\#24](https://github.com/recurly/recurly-client-node/pull/24) ([bhelx](https://github.com/bhelx))
+
+**Merged pull requests:**
+
+- Release 3.0.0-beta.5 [\#40](https://github.com/recurly/recurly-client-node/pull/40) ([bhelx](https://github.com/bhelx))
+
+## [3.0.0-beta.3](https://github.com/recurly/recurly-client-node/tree/3.0.0-beta.3) (2019-06-28)
+[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.0.0-beta.2...3.0.0-beta.3)
+
+**Implemented enhancements:**
+
+- 3.0.0.beta.3 [\#18](https://github.com/recurly/recurly-client-node/pull/18) ([bhelx](https://github.com/bhelx))
+- Latest v2018-08-09 Changes [\#17](https://github.com/recurly/recurly-client-node/pull/17) ([bhelx](https://github.com/bhelx))
+- Bump test packages [\#15](https://github.com/recurly/recurly-client-node/pull/15) ([bhelx](https://github.com/bhelx))
+- No longer need dep scripts [\#14](https://github.com/recurly/recurly-client-node/pull/14) ([bhelx](https://github.com/bhelx))
+- Url Encode Items in interpolatePath [\#13](https://github.com/recurly/recurly-client-node/pull/13) ([bhelx](https://github.com/bhelx))
+- Fix user agent [\#12](https://github.com/recurly/recurly-client-node/pull/12) ([bhelx](https://github.com/bhelx))
+- Error hierarchy [\#11](https://github.com/recurly/recurly-client-node/pull/11) ([bhelx](https://github.com/bhelx))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -10,6 +10,8 @@ npm install recurly --save-prod
 
 Or manually insert the dependency into the `dependencies` section of your `package.json`:
 
+> **Note**: We do try to strictly follow [SemVer](https://semver.org/) so locking to a major version should be safe.
+
 ```
 {
   // ...
@@ -17,6 +19,7 @@ Or manually insert the dependency into the `dependencies` section of your `packa
   // ...
 }
 ```
+> **Note**: When upgrading, view the [CHANGELOG](https://github.com/recurly/recurly-client-node/blob/master/CHANGELOG.md) to see what's changed.
 
 ### Creating a client
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2069,12 +2069,18 @@
 <pre><code>npm install recurly --save-prod
 </code></pre>
 <p>Or manually insert the dependency into the <code>dependencies</code> section of your <code>package.json</code>:</p>
+<blockquote>
+<p><strong>Note</strong>: We do try to strictly follow <a href="https://semver.org/">SemVer</a> so locking to a major version should be safe.</p>
+</blockquote>
 <pre><code>{
   // ...
   "recurly" : "^3.2.0"
   // ...
 }
 </code></pre>
+<blockquote>
+<p><strong>Note</strong>: When upgrading, view the <a href="https://github.com/recurly/recurly-client-node/blob/master/CHANGELOG.md">CHANGELOG</a> to see what's changed.</p>
+</blockquote>
 <h3>Creating a client</h3>
 <p>A client object represents a connection to the Recurly API. The client implements
 each <code>operation</code> that can be performed in the API as a method.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4325,9 +4325,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5225,9 +5225,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -7891,20 +7891,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         },

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-bump2version "$@"
+if [ "$1" == "--next-version" ]; then
+  shift
+  bump2version --dry-run --list "$@" | grep new_version | cut -d "=" -f 2
+elif [ "$1" == "--this-version" ]; then
+  cat .bumpversion.cfg | grep current_version | awk -F" = " '{print $2}'
+else
+  bump2version "$@"
+fi

--- a/scripts/changelog
+++ b/scripts/changelog
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Environment variable GITHUB_TOKEN must be set"
+else
+  if [ "$1" == "--pending" ]; then
+    github_changelog_generator -t $GITHUB_TOKEN --unreleased-only -o "$2"
+  else
+    github_changelog_generator -t $GITHUB_TOKEN
+  fi
+fi

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+# major,minor,patch
+PART=${1}
+NEXT_VERSION=$(./scripts/bump --next-version $PART)
+UNRELEASED_LOG="/tmp/node-pending-changes.md"
+
+if [ -z "$NEXT_VERSION" ]; then
+  echo "Failed to get next version"
+else
+  # Generate pending changes in tmpfile
+  ./scripts/changelog --pending $UNRELEASED_LOG
+  # Add a git message header of Release X.Y.Z
+  printf "Release $NEXT_VERSION\n\n$(cat $UNRELEASED_LOG)" > $UNRELEASED_LOG
+  # Delete credit line
+  sed -i '' -e '$ d' $UNRELEASED_LOG
+
+  git checkout -b release-$NEXT_VERSION
+
+  # Actually bump the version
+  ./scripts/bump $PART
+
+  # Rebuild docs
+  ./scripts/build
+
+  # Make the commit
+  git add . --all
+  git commit -F $UNRELEASED_LOG
+
+  # push up this branch for PR
+  git push origin release-$NEXT_VERSION
+
+  # Create the tag (but don't push it yet, it's pushed in `scripts/release`)
+  git tag -F $UNRELEASED_LOG $NEXT_VERSION
+fi

--- a/scripts/release
+++ b/scripts/release
@@ -1,4 +1,24 @@
 #!/usr/bin/env bash
 set -e
 
+# TODO this file could be gone
+RELEASED_LOG="/tmp/node-pending-changes.md"
+THIS_VERSION=$(./scripts/bump --this-version)
+
+# push the tag
+git push origin $THIS_VERSION
+
+# publish to npm
 npm publish
+
+# Finally need to update the full changelog
+./scripts/changelog
+git add CHANGELOG.md
+git commit -m "Update Changelog for Release $THIS_VERSION"
+git push origin master
+
+# Copy-pasteable messages for announcments
+echo "Npm: https://www.npmjs.com/package/recurly/v/$THIS_VERSION"
+echo "Release: https://github.com/recurly/recurly-client-node/releases/tag/$THIS_VERSION"
+echo "Changelog:"
+cat "$RELEASED_LOG"


### PR DESCRIPTION
This implements changelog-generation via https://github.com/github-changelog-generator/github-changelog-generator

I've also added some scripts to facilitate a new release process. When ready to release pending changes:

1. Make sure you are on an up-to-date `master` branch
2. Run `./scripts/prepare-release $part` where `$part` is one of `patch`, `minor`, or `major`. This will create a branch `release-X.Y.Z` (where X.Y.Z is the next version). It will then bump the version and create a commit with the unreleased changelog as the message. It will push that branch as well as create a local tag for X.Y.Z.
3. Review and merge that PR. Change back to master and pull down changes.
4. Run `./scripts/release` to publish the tag and the npm package.
5. Copy-paste output of `release` script for announcements
