### PR TITLE
Convert Array params to CSV strings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -15,7 +15,7 @@ Or manually insert the dependency into the `dependencies` section of your `packa
 ```
 {
   // ...
-  "recurly" : "^3.2.0"
+  "recurly" : "^3.2.1"
   // ...
 }
 ```

--- a/lib/recurly/Pager.js
+++ b/lib/recurly/Pager.js
@@ -10,7 +10,7 @@ class Pager {
   constructor (client, path, params) {
     this.client = client
     this.path = path
-    this.params = params
+    this.params = this._mapArrayParams(params)
   }
 
   /**
@@ -122,6 +122,20 @@ class Pager {
     }
     this._paramsConsumed = true
     return this.params
+  }
+
+  // Converts array parameters to CSV strings to maintain consistency with
+  // how the server expects the request to be formatted while providing the
+  // developer with an array type to maintain developer happiness!
+  _mapArrayParams (params) {
+    return Object.keys(params).reduce((res, key) => {
+      if (Array.isArray(params[key])) {
+        res[key] = params[key].join(',')
+      } else {
+        res[key] = params[key]
+      }
+      return res
+    }, {})
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Recurly V3 node client",
   "main": "lib/recurly.js",
   "scripts": {


### PR DESCRIPTION
Fixes an issue with requesting a list of resources with specific `ids`. The server expects a CSV string of ids, but the api spec specifies that the `ids` should be specified as an array. 

This fix maintains developer happiness by maintaining the ability to specify an array of ids that are transformed to a CSV string when the request is sent to the server.