### PR TITLE
Release 3.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.3.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -15,7 +15,7 @@ Or manually insert the dependency into the `dependencies` section of your `packa
 ```
 {
   // ...
-  "recurly" : "^3.3.0"
+  "recurly" : "^3.3.1"
   // ...
 }
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset='utf-8' />
-	<title>recurly 3.3.0 | Documentation</title>
+	<title>recurly 3.3.1 | Documentation</title>
 	<meta name='description' content='Recurly V3 node client'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>
 	<link href='assets/styles.min.css' rel='stylesheet' />
@@ -15,7 +15,7 @@
 			<div class='font-smaller fixed col-3 top-0 bottom-0 left-0 overflow-auto fill-light dark-link'>
 				<div class='px2'>
 					<h3 class='mb0 no-anchor'><code>recurly</code></h3>
-					<div class='mb1'><code>3.3.0</code></div>
+					<div class='mb1'><code>3.3.1</code></div>
 					<input placeholder='Filter' id='filter-input' class='col12 block input' type='text' />
 					<div id="toc">
 						
@@ -2074,7 +2074,7 @@
 </blockquote>
 <pre><code>{
   // ...
-  "recurly" : "^3.3.0"
+  "recurly" : "^3.3.1"
   // ...
 }
 </code></pre>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Recurly V3 node client",
   "main": "lib/recurly.js",
   "types": "lib/recurly.d.ts",


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.3.0...HEAD)

**Fixed bugs:**

- error TS2504: Type 'AsyncIterator\<Plan, any, undefined\>' must have a '\[Symbol.asyncIterator\]\(\)' method that returns an async iterator. [\#73](https://github.com/recurly/recurly-client-node/issues/73)

**Merged pull requests:**

- Pager: Use AsyncIterable not AsyncIterator [\#74](https://github.com/recurly/recurly-client-node/pull/74) ([bhelx](https://github.com/bhelx))