### PR TITLE
Use hub cli to publish release

### DIFF
--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -28,9 +28,9 @@ else
   git add . --all
   git commit -F $UNRELEASED_LOG
 
-  # push up this branch for PR
+  # Push up this branch for PR
   git push origin release-$NEXT_VERSION
 
-  # Create the tag (but don't push it yet, it's pushed in `scripts/release`)
-  git tag -F $UNRELEASED_LOG $NEXT_VERSION
+  # Create PR
+  hub pull-request -c -F $UNRELEASED_LOG
 fi

--- a/scripts/release
+++ b/scripts/release
@@ -5,17 +5,17 @@ set -e
 RELEASED_LOG="/tmp/node-pending-changes.md"
 THIS_VERSION=$(./scripts/bump --this-version)
 
-# push the tag
-git push origin $THIS_VERSION
-
-# publish to npm
-npm publish
-
 # Finally need to update the full changelog
 ./scripts/changelog
 git add CHANGELOG.md
 git commit -m "Update Changelog for Release $THIS_VERSION"
 git push origin master
+
+# publish to npm
+npm publish
+
+# create release
+hub release create -c -F $RELEASED_LOG $THIS_VERSION
 
 # Copy-pasteable messages for announcments
 echo "Npm: https://www.npmjs.com/package/recurly/v/$THIS_VERSION"


### PR DESCRIPTION
Seems like tags can only be promoted to releases through the UI or API, so I'm using [hub](https://hub.github.com/) now to create the releases. Since we're adding this dependency, i'm also using it to create a PR in `prepare-release`.