### PR TITLE
Updating .github_changelog_generator file for newer versions

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,5 @@
+user=recurly
+project=recurly-client-node
 unreleased=false
 since-tag=3.0.0-beta.2
 exclude-labels=question,bug?,duplicate


### PR DESCRIPTION
Newer versions of the `github_changelog_generator` script require that the `user` and `project` parameters be specified