### PR TITLE
Support gzip responses, improved response handling, keep-alive & timeout settings

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -6,6 +6,7 @@ const ApiError = require('./ApiError')
 const casters = require('./Caster')
 const querystring = require('querystring')
 const apiErrors = require('./api_errors')
+const networkErrors = require('./network_errors')
 const utils = require('./utils')
 const resources = require('./resources')
 const { makeRequest } = require('./Http')
@@ -13,6 +14,7 @@ const { makeRequest } = require('./Http')
 const BINARY_TYPES = [
   'application/pdf'
 ]
+const JSON_CONTENT_TYPE = 'application/json'
 
 /**
  * This is the base functionality for the Recurly.Client.
@@ -29,7 +31,9 @@ class BaseClient {
       host: 'v3.recurly.com',
       port: 443,
       agent: new https.Agent({
-        keepAlive: true
+        keepAlive: true,
+        keepAliveMsecs: 600000,
+        timeout: 10000
       })
     }
 
@@ -70,7 +74,9 @@ class BaseClient {
               // Maintain JSON parsed body for version < 4
               // TODO: Remove this (vv) for version 4
               if (recurlyResponse.body && recurlyResponse.body.length > 0) {
-                recurlyResponse.body = JSON.parse(recurlyResponse.body)
+                if (recurlyResponse.contentType && recurlyResponse.contentType.includes(JSON_CONTENT_TYPE)) {
+                  recurlyResponse.body = JSON.parse(recurlyResponse.body)
+                }
               }
             }
             resource._setResponse(recurlyResponse)
@@ -106,8 +112,9 @@ class BaseClient {
    */
   _errorFromResponse (resp) {
     let err = null
+    const jsonContent = (resp.contentType && resp.contentType.includes(JSON_CONTENT_TYPE))
 
-    if (resp.status < 200 || resp.status > 299) {
+    if (jsonContent && (resp.status < 200 || resp.status > 299)) {
       const errBody = resp.body && JSON.parse(resp.body).error
       // If we have a body, we determine the error based on
       // the contents of the body
@@ -126,7 +133,7 @@ class BaseClient {
         }
         err._setResponse(resp)
         return err
-      // if we don't have a body, we determine the error
+      // if we don't have a JSON body, we determine the error
       // based on the http status code
       } else {
         err = new ApiError('Unknown Error', 'unknown')
@@ -141,6 +148,14 @@ class BaseClient {
           err = new apiErrors.ValidationError('Request not valid', 'validation')
         } else if (resp.status === 500) {
           err = new apiErrors.InternalServerError('Recurly Server Error', 'internal_server_error')
+        } else if (resp.status === 502) {
+          err = new networkErrors.ServiceUnavailableError('Recurly Service Unavialable Error', 'bad_gateway')
+        } else if (resp.status === 503) {
+          err = new networkErrors.ServiceUnavailableError('Recurly Service Unavialable Error', 'service_unavailable')
+        } else if (resp.status === 504) {
+          err = new networkErrors.TimeoutError('Recurly Timeout', 'gateway_timeout')
+        } else {
+          err = new networkErrors.UnexpectedResponseError('Unexpected Response', 'unexpected_response')
         }
 
         err._setResponse(resp)

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -115,25 +115,27 @@ class BaseClient {
     let err = null
     const jsonContent = (resp.contentType && resp.contentType.includes(JSON_CONTENT_TYPE))
 
-    if (jsonContent && (resp.status < 200 || resp.status > 299)) {
-      const errBody = resp.body && JSON.parse(resp.body).error
-      // If we have a body, we determine the error based on
-      // the contents of the body
-      if (errBody) {
-        let className = utils.classify(errBody.type)
-        if (!className.endsWith('Error')) className += 'Error'
-        const ErrClass = apiErrors[className] || ApiError
-        if (ErrClass === apiErrors.TransactionError) {
-          err = new ErrClass(errBody.message, errBody.type, {
-            transactionError: resources.TransactionError.cast(errBody.transaction_error)
-          })
-        } else {
-          err = new ErrClass(errBody.message, errBody.type, {
-            params: errBody.params || []
-          })
+    if (resp.status < 200 || resp.status > 299) {
+      if (jsonContent) {
+        const errBody = resp.body && JSON.parse(resp.body).error
+        // If we have a body, we determine the error based on
+        // the contents of the body
+        if (errBody) {
+          let className = utils.classify(errBody.type)
+          if (!className.endsWith('Error')) className += 'Error'
+          const ErrClass = apiErrors[className] || ApiError
+          if (ErrClass === apiErrors.TransactionError) {
+            err = new ErrClass(errBody.message, errBody.type, {
+              transactionError: resources.TransactionError.cast(errBody.transaction_error)
+            })
+          } else {
+            err = new ErrClass(errBody.message, errBody.type, {
+              params: errBody.params || []
+            })
+          }
+          err._setResponse(resp)
+          return err
         }
-        err._setResponse(resp)
-        return err
       // if we don't have a JSON body, we determine the error
       // based on the http status code
       } else {

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -100,7 +100,8 @@ class BaseClient {
       'Accept': `application/vnd.recurly.${this.apiVersion()}`,
       'User-Agent': `Recurly/${pkg.version}; node`,
       'Authorization': 'Basic ' + Buffer.from(this._getApiKey() + ':', 'ascii').toString('base64'),
-      'Content-Type': 'application/json'
+      'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6',
+      'Content-Type': 'application/json; charset=utf-8'
     }
 
     return options

--- a/lib/recurly/Http.js
+++ b/lib/recurly/Http.js
@@ -1,9 +1,11 @@
 const https = require('https')
 const casters = require('./Caster')
+const networkErrors = require('./network_errors')
 
 const BINARY_TYPES = [
   'application/pdf'
 ]
+const TIMEOUT = 60000
 
 function responseEncoding (contentType = '') {
   const isBinary = BINARY_TYPES.find((binaryType) => contentType.includes(binaryType))
@@ -18,21 +20,45 @@ function makeRequest (options, requestBody) {
     options.headers['Content-Length'] = Buffer.byteLength(requestBody)
   }
   return new Promise((resolve, reject) => {
-    const httpRequest = https.request(options, (httpResponse) => {
-      const rbody = []
-      httpResponse.setEncoding(responseEncoding(httpResponse.headers['content-type']))
-      httpResponse.on('data', chunk => rbody.push(chunk))
-      httpResponse.on('end', () => {
-        const recurlyRequest = new Request(options.method, options.path, requestBody)
-        const recurlyResponse = Response.build(httpResponse, rbody, recurlyRequest)
-        resolve(recurlyResponse)
+    let aborted = false
+
+    const submitRequest = () => {
+      const httpRequest = https.request(options, (httpResponse) => {
+        const rbody = []
+        httpResponse.setEncoding(responseEncoding(httpResponse.headers['content-type']))
+        httpResponse.on('data', chunk => rbody.push(chunk))
+        httpResponse.on('end', () => {
+          const recurlyRequest = new Request(options.method, options.path, requestBody)
+          const recurlyResponse = Response.build(httpResponse, rbody, recurlyRequest)
+          resolve(recurlyResponse)
+        })
       })
-    })
-    httpRequest.on('error', reject)
-    if (requestBody) {
-      httpRequest.write(requestBody)
+      httpRequest.setTimeout(TIMEOUT, () => {
+        aborted = true
+        httpRequest.abort()
+        reject(new networkErrors.TimeoutError('Timeout while sending request'))
+      })
+      httpRequest.on('error', (err) => {
+        if (aborted) {
+          return
+        }
+
+        // when using keep-alive, we need to retry requests if the socket is reset
+        // https://nodejs.org/api/http.html#http_request_reusedsocket
+        if (!options.retried && err.code === 'ECONNRESET') {
+          options.retried = true
+          submitRequest()
+        } else {
+          reject(err)
+        }
+      })
+      if (requestBody) {
+        httpRequest.write(requestBody)
+      }
+      httpRequest.end()
     }
-    httpRequest.end()
+
+    submitRequest()
   })
 }
 

--- a/lib/recurly/Http.js
+++ b/lib/recurly/Http.js
@@ -1,4 +1,5 @@
 const https = require('https')
+const zlib = require('zlib')
 const casters = require('./Caster')
 const networkErrors = require('./network_errors')
 
@@ -6,6 +7,11 @@ const BINARY_TYPES = [
   'application/pdf'
 ]
 const TIMEOUT = 60000
+
+const ZLIB_OPTIONS = {
+  flush: zlib.Z_SYNC_FLUSH,
+  finishFlush: zlib.Z_SYNC_FLUSH
+}
 
 function responseEncoding (contentType = '') {
   const isBinary = BINARY_TYPES.find((binaryType) => contentType.includes(binaryType))
@@ -24,10 +30,25 @@ function makeRequest (options, requestBody) {
 
     const submitRequest = () => {
       const httpRequest = https.request(options, (httpResponse) => {
-        const rbody = []
-        httpResponse.setEncoding(responseEncoding(httpResponse.headers['content-type']))
-        httpResponse.on('data', chunk => rbody.push(chunk))
-        httpResponse.on('end', () => {
+        var responseStream
+        const encoding = httpResponse.headers['content-encoding']
+
+        if (encoding === 'gzip') {
+          responseStream = zlib.createGunzip(ZLIB_OPTIONS)
+          httpResponse.pipe(responseStream)
+        } else if (encoding === 'deflate') {
+          responseStream = zlib.createInflate(ZLIB_OPTIONS)
+          httpResponse.pipe(responseStream)
+        } else {
+          responseStream = httpResponse
+        }
+        responseStream.setEncoding(responseEncoding(httpResponse.headers['content-type']))
+
+        const chunks = []
+        responseStream.on('data', chunk => chunks.push(chunk))
+        responseStream.on('end', () => {
+          const rbody = chunks.join('')
+
           const recurlyRequest = new Request(options.method, options.path, requestBody)
           const recurlyResponse = Response.build(httpResponse, rbody, recurlyRequest)
           resolve(recurlyResponse)
@@ -68,7 +89,7 @@ class Response {
     resp.request = request
     resp.body = null
     if (body && body.length > 0) {
-      resp.body = body.join('')
+      resp.body = body
     }
     resp.status = response.statusCode
     resp.requestId = response.headers['x-request-id']

--- a/lib/recurly/network_errors.js
+++ b/lib/recurly/network_errors.js
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+'use strict'
+
+let ApiError = require('./ApiError')
+
+class ServiceUnavailableError extends ApiError { }
+
+class TimeoutError extends ApiError { }
+
+class UnexpectedResponseError extends ApiError { }
+
+module.exports = {
+
+  ServiceUnavailableError: ServiceUnavailableError,
+
+  TimeoutError: TimeoutError,
+
+  UnexpectedResponseError: UnexpectedResponseError
+}

--- a/test/mock_client.js
+++ b/test/mock_client.js
@@ -48,6 +48,7 @@ class MockClient extends BaseClient {
       const req = new Request(options.method, options.path, requestBody)
       const resp = new Response()
       resp.request = req
+      resp.contentType = 'application/json'
       return strategy(resp, options)
     })
   }

--- a/test/recurly/Http.test.js
+++ b/test/recurly/Http.test.js
@@ -28,7 +28,8 @@ describe('Http', () => {
             'Recurly-Deprecated': 'false',
             'date': 'Monday',
             'server': 'cloudflare',
-            'cf-ray': 'cf-1234'
+            'cf-ray': 'cf-1234',
+            'content-type': 'application/json; charset=utf-8'
           }
         }
       }


### PR DESCRIPTION
* Only call JSON.parse when the response content-type is `application/json`
* Better error handling should a load balancer responds with an HTML response instead of JSON
* Set request keep-alive duration to 10 minutes, set connect timeout to 10 seconds
* Safely retry requests when using keep-alive if they return ECONNRESET due to being reset
* Set a request timeout of 60 seconds
* Supports gzip and deflate for response bodies. This allows the client to use less bandwidth and more efficiently paginate through large lists.