### PR TITLE
Fix terminateSubscription params

### DIFF
--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -2890,7 +2890,7 @@ class Client extends BaseClient {
   async terminateSubscription (subscriptionId, params = {}) {
     let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, params)
   }
 
   /**

--- a/test/recurly/Client.test.js
+++ b/test/recurly/Client.test.js
@@ -1,0 +1,34 @@
+/* globals describe, it, beforeEach, afterEach */
+
+require('../test_helper')
+const sinon = require('sinon')
+const assert = require('assert').strict
+const BaseClient = require('../../lib/recurly/BaseClient')
+const Client = require('../../lib/recurly/Client')
+
+describe('Client', () => {
+  let makeRequestStub
+  let client
+
+  beforeEach(() => {
+    makeRequestStub = sinon.stub(BaseClient.prototype, '_makeRequest')
+      .resolves({})
+    client = new Client('myapikey')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('#terminateSubscription', () => {
+    it('Should pass empty params', async () => {
+      await client.terminateSubscription('abcxyz')
+      assert(makeRequestStub.calledWith('DELETE', '/subscriptions/abcxyz', {}))
+    })
+
+    it('Should pass non-empty params', async () => {
+      await client.terminateSubscription('abcxyz', { refund: 'full' })
+      assert(makeRequestStub.calledWith('DELETE', '/subscriptions/abcxyz', { refund: 'full' }))
+    })
+  })
+})


### PR DESCRIPTION
I was trying to terminate a subscription with a full refund and figured out that the `params` arg was not being passed to `_makeRequest`. I've verified this fixes it.

Writing the test was probably overkill, but at least it won't come up again now. ;)