### PR TITLE
Release 3.5.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.0
+current_version = 3.5.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -15,7 +15,7 @@ Or manually insert the dependency into the `dependencies` section of your `packa
 ```
 {
   // ...
-  "recurly" : "^3.5.0"
+  "recurly" : "^3.5.1"
   // ...
 }
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset='utf-8' />
-	<title>recurly 3.5.0 | Documentation</title>
+	<title>recurly 3.5.1 | Documentation</title>
 	<meta name='description' content='Recurly V3 node client'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>
 	<link href='assets/styles.min.css' rel='stylesheet' />
@@ -15,7 +15,7 @@
 			<div class='font-smaller fixed col-3 top-0 bottom-0 left-0 overflow-auto fill-light dark-link'>
 				<div class='px2'>
 					<h3 class='mb0 no-anchor'><code>recurly</code></h3>
-					<div class='mb1'><code>3.5.0</code></div>
+					<div class='mb1'><code>3.5.1</code></div>
 					<input placeholder='Filter' id='filter-input' class='col12 block input' type='text' />
 					<div id="toc">
 						
@@ -2108,7 +2108,7 @@
 </blockquote>
 <pre><code>{
   // ...
-  "recurly" : "^3.5.0"
+  "recurly" : "^3.5.1"
   // ...
 }
 </code></pre>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Recurly V3 node client",
   "main": "lib/recurly.js",
   "types": "lib/recurly.d.ts",


### PR DESCRIPTION
# Changelog

[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.5.0...HEAD)

**Merged pull requests:**

- Passing params object into \_makeRequest where applicable [\#95](https://github.com/recurly/recurly-client-node/pull/95) ([douglasmiller](https://github.com/douglasmiller))
- Updating release script to be uniform across all clients [\#93](https://github.com/recurly/recurly-client-node/pull/93) ([douglasmiller](https://github.com/douglasmiller))
- Thu Mar 26 20:45:12 UTC 2020 Upgrade API version v2019-10-10 [\#92](https://github.com/recurly/recurly-client-node/pull/92) ([bhelx](https://github.com/bhelx))