### PR TITLE
Update method parameter 'params' to 'options' and related doc comments

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2400,7 +2400,7 @@ Read more about the security implications of parsing untrusted XML in <a href="h
 		<a class='black' href='#clientlistsites'>
 			<code>
 				listSites
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -2426,19 +2426,30 @@ Read more about the security implications of parsing untrusted XML in <a href="h
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -2460,9 +2471,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -2472,9 +2483,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -2484,9 +2495,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -2500,6 +2511,9 @@ order. In descending order updated records will move behind the cursor and could
 prevent some records from being returned.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -2639,7 +2653,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccounts'>
 			<code>
 				listAccounts
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -2665,19 +2679,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -2699,9 +2724,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -2711,9 +2736,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -2723,9 +2748,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -2741,9 +2766,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -2760,9 +2785,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -2779,9 +2804,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.email</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.email</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -2795,9 +2820,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.subscriber</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.subscriber</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
     
@@ -2814,9 +2839,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.pastDue</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.pastDue</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -2826,6 +2851,9 @@ prevent some records from being returned.
  state.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -4156,7 +4184,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountcouponredemptions'>
 			<code>
 				listAccountCouponRedemptions
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -4199,19 +4227,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -4233,9 +4272,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -4251,9 +4290,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -4270,9 +4309,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -4287,6 +4326,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -4612,7 +4654,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountcreditpayments'>
 			<code>
 				listAccountCreditPayments
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -4655,19 +4697,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -4677,9 +4730,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -4689,9 +4742,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -4707,9 +4760,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -4726,9 +4779,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -4743,6 +4796,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -4799,7 +4855,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountinvoices'>
 			<code>
 				listAccountInvoices
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -4842,19 +4898,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -4876,9 +4943,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -4888,9 +4955,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -4900,9 +4967,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -4918,9 +4985,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -4937,9 +5004,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -4956,9 +5023,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -4972,6 +5039,9 @@ prevent some records from being returned.
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -5256,7 +5326,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountlineitems'>
 			<code>
 				listAccountLineItems
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -5299,19 +5369,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -5333,9 +5414,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -5345,9 +5426,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5357,9 +5438,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5375,9 +5456,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -5394,9 +5475,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -5413,9 +5494,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.original</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.original</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5425,9 +5506,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5437,9 +5518,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5447,6 +5528,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by type field.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -5611,7 +5695,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountnotes'>
 			<code>
 				listAccountNotes
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -5654,19 +5738,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -5686,6 +5781,9 @@ returned at once you can sort the records yourself.</li>
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -5856,7 +5954,7 @@ returned at once you can sort the records yourself.</li>
 		<a class='black' href='#clientlistshippingaddresses'>
 			<code>
 				listShippingAddresses
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -5899,19 +5997,30 @@ returned at once you can sort the records yourself.</li>
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -5933,9 +6042,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -5945,9 +6054,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5957,9 +6066,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -5975,9 +6084,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -5994,9 +6103,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -6011,6 +6120,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -6543,7 +6655,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountsubscriptions'>
 			<code>
 				listAccountSubscriptions
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -6586,19 +6698,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -6620,9 +6743,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -6632,9 +6755,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6644,9 +6767,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6662,9 +6785,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -6681,9 +6804,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -6700,9 +6823,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6715,6 +6838,9 @@ prevent some records from being returned.
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -6761,7 +6887,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccounttransactions'>
 			<code>
 				listAccountTransactions
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -6804,19 +6930,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -6838,9 +6975,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -6850,9 +6987,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6862,9 +6999,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6880,9 +7017,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -6899,9 +7036,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -6918,9 +7055,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6936,9 +7073,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.success</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.success</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -6946,6 +7083,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by success field.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -6992,7 +7132,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistchildaccounts'>
 			<code>
 				listChildAccounts
-				<span class='gray'>(accountId, params)</span>
+				<span class='gray'>(accountId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -7035,19 +7175,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -7069,9 +7220,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -7081,9 +7232,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7093,9 +7244,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7111,9 +7262,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -7130,9 +7281,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -7149,9 +7300,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.email</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.email</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7165,9 +7316,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.subscriber</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.subscriber</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
     
@@ -7184,9 +7335,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.pastDue</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.pastDue</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7196,6 +7347,9 @@ prevent some records from being returned.
  state.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -7242,7 +7396,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaccountacquisition'>
 			<code>
 				listAccountAcquisition
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -7268,19 +7422,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -7302,9 +7467,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -7314,9 +7479,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7326,9 +7491,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7344,9 +7509,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -7363,9 +7528,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -7380,6 +7545,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -7426,7 +7594,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistcoupons'>
 			<code>
 				listCoupons
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -7452,19 +7620,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -7486,9 +7665,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -7498,9 +7677,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7510,9 +7689,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -7528,9 +7707,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -7547,9 +7726,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -7564,6 +7743,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -7976,7 +8158,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistuniquecouponcodes'>
 			<code>
 				listUniqueCouponCodes
-				<span class='gray'>(couponId, params)</span>
+				<span class='gray'>(couponId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -8019,19 +8201,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -8053,9 +8246,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -8065,9 +8258,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8077,9 +8270,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8095,9 +8288,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8114,9 +8307,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8131,6 +8324,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -8177,7 +8373,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistcreditpayments'>
 			<code>
 				listCreditPayments
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -8203,19 +8399,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -8225,9 +8432,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8237,9 +8444,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8255,9 +8462,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8274,9 +8481,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8291,6 +8498,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -8430,7 +8640,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistcustomfielddefinitions'>
 			<code>
 				listCustomFieldDefinitions
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -8456,19 +8666,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -8490,9 +8711,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -8502,9 +8723,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8514,9 +8735,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8532,9 +8753,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8551,9 +8772,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8570,9 +8791,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.relatedType</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.relatedType</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8580,6 +8801,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by related type.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -8732,7 +8956,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistitems'>
 			<code>
 				listItems
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -8758,19 +8982,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -8792,9 +9027,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -8804,9 +9039,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8816,9 +9051,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8834,9 +9069,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8853,9 +9088,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -8872,9 +9107,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -8882,6 +9117,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by state.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -9467,7 +9705,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistinvoices'>
 			<code>
 				listInvoices
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -9493,19 +9731,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -9527,9 +9776,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -9539,9 +9788,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -9551,9 +9800,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -9569,9 +9818,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -9588,9 +9837,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -9607,9 +9856,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -9623,6 +9872,9 @@ prevent some records from being returned.
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -10010,7 +10262,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientcollectinvoice'>
 			<code>
 				collectInvoice
-				<span class='gray'>(invoiceId, params)</span>
+				<span class='gray'>(invoiceId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -10053,19 +10305,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.body</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.body</td>
   <td class="col-2 quiet">
     InvoiceCollect
     
@@ -10073,6 +10336,9 @@ prevent some records from being returned.
   <td class='col-8'>The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -10528,7 +10794,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistinvoicelineitems'>
 			<code>
 				listInvoiceLineItems
-				<span class='gray'>(invoiceId, params)</span>
+				<span class='gray'>(invoiceId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -10571,19 +10837,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -10605,9 +10882,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -10617,9 +10894,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -10629,9 +10906,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -10647,9 +10924,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -10666,9 +10943,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -10685,9 +10962,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.original</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.original</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -10697,9 +10974,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -10709,9 +10986,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -10719,6 +10996,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by type field.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -10765,7 +11045,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistinvoicecouponredemptions'>
 			<code>
 				listInvoiceCouponRedemptions
-				<span class='gray'>(invoiceId, params)</span>
+				<span class='gray'>(invoiceId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -10808,19 +11088,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -10842,9 +11133,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -10860,9 +11151,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -10879,9 +11170,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -10896,6 +11187,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -10942,7 +11236,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistrelatedinvoices'>
 			<code>
 				listRelatedInvoices
-				<span class='gray'>(invoiceId, params)</span>
+				<span class='gray'>(invoiceId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -10985,7 +11279,7 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				any
 				
@@ -11166,7 +11460,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistlineitems'>
 			<code>
 				listLineItems
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -11192,19 +11486,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -11226,9 +11531,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -11238,9 +11543,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11250,9 +11555,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11268,9 +11573,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -11287,9 +11592,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -11306,9 +11611,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.original</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.original</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11318,9 +11623,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11330,9 +11635,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11340,6 +11645,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by type field.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -11588,7 +11896,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistplans'>
 			<code>
 				listPlans
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -11614,19 +11922,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -11648,9 +11967,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -11660,9 +11979,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11672,9 +11991,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11690,9 +12009,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -11709,9 +12028,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -11728,9 +12047,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -11738,6 +12057,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by state.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -12220,7 +12542,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistplanaddons'>
 			<code>
 				listPlanAddOns
-				<span class='gray'>(planId, params)</span>
+				<span class='gray'>(planId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -12263,19 +12585,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -12297,9 +12630,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -12309,9 +12642,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -12321,9 +12654,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -12339,9 +12672,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -12358,9 +12691,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -12377,9 +12710,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -12387,6 +12720,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by state.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -12838,7 +13174,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistaddons'>
 			<code>
 				listAddOns
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -12864,19 +13200,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -12898,9 +13245,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -12910,9 +13257,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -12922,9 +13269,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -12940,9 +13287,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -12959,9 +13306,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -12978,9 +13325,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -12988,6 +13335,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by state.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -13117,7 +13467,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistshippingmethods'>
 			<code>
 				listShippingMethods
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -13143,19 +13493,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -13177,9 +13538,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -13189,9 +13550,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -13201,9 +13562,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -13219,9 +13580,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -13238,9 +13599,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -13255,6 +13616,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -13384,7 +13748,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistsubscriptions'>
 			<code>
 				listSubscriptions
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -13410,19 +13774,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -13444,9 +13819,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -13456,9 +13831,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -13468,9 +13843,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -13486,9 +13861,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -13505,9 +13880,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -13524,9 +13899,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -13539,6 +13914,9 @@ prevent some records from being returned.
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -13918,7 +14296,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientterminatesubscription'>
 			<code>
 				terminateSubscription
-				<span class='gray'>(subscriptionId, params)</span>
+				<span class='gray'>(subscriptionId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -13961,19 +14339,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.refund</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.refund</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -13994,6 +14383,9 @@ prevent some records from being returned.
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -14059,7 +14451,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientcancelsubscription'>
 			<code>
 				cancelSubscription
-				<span class='gray'>(subscriptionId, params)</span>
+				<span class='gray'>(subscriptionId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -14102,19 +14494,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.body</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.body</td>
   <td class="col-2 quiet">
     SubscriptionCancel
     
@@ -14122,6 +14525,9 @@ prevent some records from being returned.
   <td class='col-8'>The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -14872,7 +15278,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistsubscriptioninvoices'>
 			<code>
 				listSubscriptionInvoices
-				<span class='gray'>(subscriptionId, params)</span>
+				<span class='gray'>(subscriptionId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -14915,19 +15321,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -14949,9 +15366,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -14961,9 +15378,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -14973,9 +15390,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -14991,9 +15408,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15010,9 +15427,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15029,9 +15446,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15045,6 +15462,9 @@ prevent some records from being returned.
 </ul>
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -15091,7 +15511,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistsubscriptionlineitems'>
 			<code>
 				listSubscriptionLineItems
-				<span class='gray'>(subscriptionId, params)</span>
+				<span class='gray'>(subscriptionId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -15134,19 +15554,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -15168,9 +15599,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -15180,9 +15611,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15192,9 +15623,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15210,9 +15641,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15229,9 +15660,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15248,9 +15679,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.original</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.original</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15260,9 +15691,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.state</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.state</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15272,9 +15703,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15282,6 +15713,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by type field.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -15328,7 +15762,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlistsubscriptioncouponredemptions'>
 			<code>
 				listSubscriptionCouponRedemptions
-				<span class='gray'>(subscriptionId, params)</span>
+				<span class='gray'>(subscriptionId, options)</span>
 			</code>
 		</a>
 	</h3>
@@ -15371,19 +15805,30 @@ prevent some records from being returned.
 		
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -15405,9 +15850,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15423,9 +15868,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15442,9 +15887,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15459,6 +15904,9 @@ prevent some records from being returned.
  this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 </td>
 </tr>
+
+
+  
 
 
 		
@@ -15505,7 +15953,7 @@ prevent some records from being returned.
 		<a class='black' href='#clientlisttransactions'>
 			<code>
 				listTransactions
-				<span class='gray'>(params)</span>
+				<span class='gray'>(options)</span>
 			</code>
 		</a>
 	</h3>
@@ -15531,19 +15979,30 @@ prevent some records from being returned.
 		</thead>
 		
 		<tr>
-			<td class='col-3 strong'><code>params</code></td>
+			<td class='col-3 strong'><code>options</code></td>
 			<td class='col-3 quiet'>
 				<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>The optional url parameters for this request.
+			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
 </td>
 		</tr>
 		
 		
 		<tr>
-  <td class='col-2 strong'>params.ids</td>
+  <td class='col-2 strong'>options.params</td>
+  <td class="col-2 quiet">
+    <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    
+  </td>
+  <td class='col-8'>The optional url parameters for this request.
+</td>
+</tr>
+
+  
+    <tr>
+  <td class='col-2 strong'>options.params.ids</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>
     
@@ -15565,9 +16024,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.limit</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.limit</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
     
@@ -15577,9 +16036,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.order</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.order</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15589,9 +16048,9 @@ returned at once you can sort the records yourself.</li>
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.sort</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.sort</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15607,9 +16066,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.beginTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.beginTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15626,9 +16085,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.endTime</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.endTime</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a>
     
@@ -15645,9 +16104,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.type</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.type</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15663,9 +16122,9 @@ prevent some records from being returned.
 </tr>
 
 
-		
-		<tr>
-  <td class='col-2 strong'>params.success</td>
+  
+    <tr>
+  <td class='col-2 strong'>options.params.success</td>
   <td class="col-2 quiet">
     <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     
@@ -15673,6 +16132,9 @@ prevent some records from being returned.
   <td class='col-8'>Filter by success field.
 </td>
 </tr>
+
+
+  
 
 
 		

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -32,8 +32,9 @@ class Client extends BaseClient {
    *   console.log(site.subdomain)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -45,18 +46,18 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
    * @return {Pager<Site>} A list of sites.
    */
-  listSites (params = {}) {
+  listSites (options = {}) {
     let path = '/sites'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -86,8 +87,9 @@ class Client extends BaseClient {
    *   console.log(account.code)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -99,29 +101,29 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-   * @param {boolean} params.subscriber - Filter for accounts with or without a subscription in the `active`,
+   * @param {string} options.params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+   * @param {boolean} options.params.subscriber - Filter for accounts with or without a subscription in the `active`,
    *   `canceled`, or `future` state.
    *
-   * @param {string} params.pastDue - Filter for accounts with an invoice in the `past_due` state.
+   * @param {string} options.params.pastDue - Filter for accounts with an invoice in the `past_due` state.
    * @return {Pager<Account>} A list of the site's accounts.
    */
-  listAccounts (params = {}) {
+  listAccounts (options = {}) {
     let path = '/accounts'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -517,8 +519,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -530,22 +533,22 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on an account.
    */
-  listAccountCouponRedemptions (accountId, params = {}) {
+  listAccountCouponRedemptions (accountId, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -622,25 +625,26 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CreditPayment>} A list of the account's credit payments.
    */
-  listAccountCreditPayments (accountId, params = {}) {
+  listAccountCreditPayments (accountId, options = {}) {
     let path = '/accounts/{account_id}/credit_payments'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -650,8 +654,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -663,19 +668,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.type - Filter by type when:
+   * @param {string} options.params.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -683,10 +688,10 @@ class Client extends BaseClient {
    *
    * @return {Pager<Invoice>} A list of the account's invoices.
    */
-  listAccountInvoices (accountId, params = {}) {
+  listAccountInvoices (accountId, options = {}) {
     let path = '/accounts/{account_id}/invoices'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -770,8 +775,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -783,27 +789,27 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.original - Filter by original field.
-   * @param {string} params.state - Filter by state field.
-   * @param {string} params.type - Filter by type field.
+   * @param {string} options.params.original - Filter by original field.
+   * @param {string} options.params.state - Filter by state field.
+   * @param {string} options.params.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the account's line items.
    */
-  listAccountLineItems (accountId, params = {}) {
+  listAccountLineItems (accountId, options = {}) {
     let path = '/accounts/{account_id}/line_items'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -855,8 +861,9 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -870,10 +877,10 @@ class Client extends BaseClient {
    *
    * @return {Pager<AccountNote>} A list of an account's notes.
    */
-  listAccountNotes (accountId, params = {}) {
+  listAccountNotes (accountId, options = {}) {
     let path = '/accounts/{account_id}/notes'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -921,8 +928,9 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -934,24 +942,24 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<ShippingAddress>} A list of an account's shipping addresses.
    */
-  listShippingAddresses (accountId, params = {}) {
+  listShippingAddresses (accountId, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1099,8 +1107,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1112,19 +1121,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.state - Filter by state.
+   * @param {string} options.params.state - Filter by state.
    *
    *   - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
    *   - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
@@ -1132,10 +1141,10 @@ class Client extends BaseClient {
    *
    * @return {Pager<Subscription>} A list of the account's subscriptions.
    */
-  listAccountSubscriptions (accountId, params = {}) {
+  listAccountSubscriptions (accountId, options = {}) {
     let path = '/accounts/{account_id}/subscriptions'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1145,8 +1154,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1158,26 +1168,26 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-   * @param {string} params.success - Filter by success field.
+   * @param {string} options.params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+   * @param {string} options.params.success - Filter by success field.
    * @return {Pager<Transaction>} A list of the account's transactions.
    */
-  listAccountTransactions (accountId, params = {}) {
+  listAccountTransactions (accountId, options = {}) {
     let path = '/accounts/{account_id}/transactions'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1187,8 +1197,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1200,29 +1211,29 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-   * @param {boolean} params.subscriber - Filter for accounts with or without a subscription in the `active`,
+   * @param {string} options.params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+   * @param {boolean} options.params.subscriber - Filter for accounts with or without a subscription in the `active`,
    *   `canceled`, or `future` state.
    *
-   * @param {string} params.pastDue - Filter for accounts with an invoice in the `past_due` state.
+   * @param {string} options.params.pastDue - Filter for accounts with an invoice in the `past_due` state.
    * @return {Pager<Account>} A list of an account's child accounts.
    */
-  listChildAccounts (accountId, params = {}) {
+  listChildAccounts (accountId, options = {}) {
     let path = '/accounts/{account_id}/accounts'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1231,8 +1242,9 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_account_acquisition}
    *
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1244,24 +1256,24 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<AccountAcquisition>} A list of the site's account acquisition data.
    */
-  listAccountAcquisition (params = {}) {
+  listAccountAcquisition (options = {}) {
     let path = '/acquisitions'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1276,8 +1288,9 @@ class Client extends BaseClient {
    *   console.log(coupon.code)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1289,24 +1302,24 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<Coupon>} A list of the site's coupons.
    */
-  listCoupons (params = {}) {
+  listCoupons (options = {}) {
     let path = '/coupons'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1392,8 +1405,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1405,24 +1419,24 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<UniqueCouponCode>} A list of unique coupon codes that were generated
    */
-  listUniqueCouponCodes (couponId, params = {}) {
+  listUniqueCouponCodes (couponId, options = {}) {
     let path = '/coupons/{coupon_id}/unique_coupon_codes'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1437,25 +1451,26 @@ class Client extends BaseClient {
    *   console.log(payment.uuid)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CreditPayment>} A list of the site's credit payments.
    */
-  listCreditPayments (params = {}) {
+  listCreditPayments (options = {}) {
     let path = '/credit_payments'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1485,8 +1500,9 @@ class Client extends BaseClient {
    *   console.log(definition.displayName)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1498,25 +1514,25 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.relatedType - Filter by related type.
+   * @param {string} options.params.relatedType - Filter by related type.
    * @return {Pager<CustomFieldDefinition>} A list of the site's custom field definitions.
    */
-  listCustomFieldDefinitions (params = {}) {
+  listCustomFieldDefinitions (options = {}) {
     let path = '/custom_field_definitions'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1561,8 +1577,9 @@ class Client extends BaseClient {
    *   console.log(item.code)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1574,25 +1591,25 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.state - Filter by state.
+   * @param {string} options.params.state - Filter by state.
    * @return {Pager<Item>} A list of the site's items.
    */
-  listItems (params = {}) {
+  listItems (options = {}) {
     let path = '/items'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1772,8 +1789,9 @@ class Client extends BaseClient {
    *   console.log(invoice.number)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1785,19 +1803,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.type - Filter by type when:
+   * @param {string} options.params.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -1805,10 +1823,10 @@ class Client extends BaseClient {
    *
    * @return {Pager<Invoice>} A list of the site's invoices.
    */
-  listInvoices (params = {}) {
+  listInvoices (options = {}) {
     let path = '/invoices'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -1938,15 +1956,16 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {InvoiceCollect} params.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {InvoiceCollect} options.params.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async collectInvoice (invoiceId, params = {}) {
-    const body = params['body']
+  async collectInvoice (invoiceId, options = {}) {
+    const body = options['body']
     let path = '/invoices/{invoice_id}/collect'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, body, params)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2062,8 +2081,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2075,27 +2095,27 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.original - Filter by original field.
-   * @param {string} params.state - Filter by state field.
-   * @param {string} params.type - Filter by type field.
+   * @param {string} options.params.original - Filter by original field.
+   * @param {string} options.params.state - Filter by state field.
+   * @param {string} options.params.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the invoice's line items.
    */
-  listInvoiceLineItems (invoiceId, params = {}) {
+  listInvoiceLineItems (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/line_items'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2105,8 +2125,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2118,22 +2139,22 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions associated with the invoice.
    */
-  listInvoiceCouponRedemptions (invoiceId, params = {}) {
+  listInvoiceCouponRedemptions (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/coupon_redemptions'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2151,10 +2172,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Pager<Invoice>} A list of the credit or charge invoices associated with the invoice.
    */
-  listRelatedInvoices (invoiceId, params = {}) {
+  listRelatedInvoices (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/related_invoices'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2207,8 +2228,9 @@ class Client extends BaseClient {
    *   console.log(`Item ${item.id} for ${item.amount}`)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2220,27 +2242,27 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.original - Filter by original field.
-   * @param {string} params.state - Filter by state field.
-   * @param {string} params.type - Filter by type field.
+   * @param {string} options.params.original - Filter by original field.
+   * @param {string} options.params.state - Filter by state field.
+   * @param {string} options.params.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the site's line items.
    */
-  listLineItems (params = {}) {
+  listLineItems (options = {}) {
     let path = '/line_items'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2315,8 +2337,9 @@ class Client extends BaseClient {
    *   console.log(plan.code)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2328,25 +2351,25 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.state - Filter by state.
+   * @param {string} options.params.state - Filter by state.
    * @return {Pager<Plan>} A list of plans.
    */
-  listPlans (params = {}) {
+  listPlans (options = {}) {
     let path = '/plans'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2490,8 +2513,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2503,25 +2527,25 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.state - Filter by state.
+   * @param {string} options.params.state - Filter by state.
    * @return {Pager<AddOn>} A list of add-ons.
    */
-  listPlanAddOns (planId, params = {}) {
+  listPlanAddOns (planId, options = {}) {
     let path = '/plans/{plan_id}/add_ons'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2595,8 +2619,9 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_add_ons}
    *
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2608,25 +2633,25 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.state - Filter by state.
+   * @param {string} options.params.state - Filter by state.
    * @return {Pager<AddOn>} A list of add-ons.
    */
-  listAddOns (params = {}) {
+  listAddOns (options = {}) {
     let path = '/add_ons'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2650,8 +2675,9 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_shipping_methods}
    *
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2663,24 +2689,24 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<ShippingMethod>} A list of the site's shipping methods.
    */
-  listShippingMethods (params = {}) {
+  listShippingMethods (options = {}) {
     let path = '/shipping_methods'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2710,8 +2736,9 @@ class Client extends BaseClient {
    *   console.log(subscription.uuid)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2723,19 +2750,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.state - Filter by state.
+   * @param {string} options.params.state - Filter by state.
    *
    *   - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
    *   - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
@@ -2743,10 +2770,10 @@ class Client extends BaseClient {
    *
    * @return {Pager<Subscription>} A list of the site's subscriptions.
    */
-  listSubscriptions (params = {}) {
+  listSubscriptions (options = {}) {
     let path = '/subscriptions'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -2874,8 +2901,9 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {string} params.refund - The type of refund to perform:
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {string} options.params.refund - The type of refund to perform:
    *
    *   * `full` - Performs a full refund of the last invoice for the current subscription term.
    *   * `partial` - Prorates a refund based on the amount of time remaining in the current bill cycle.
@@ -2887,10 +2915,10 @@ class Client extends BaseClient {
    *
    * @return {Promise<Subscription>} An expired subscription.
    */
-  async terminateSubscription (subscriptionId, params = {}) {
+  async terminateSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('DELETE', path, null, params)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2915,15 +2943,16 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {SubscriptionCancel} params.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {SubscriptionCancel} options.params.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
    * @return {Promise<Subscription>} A canceled or failed subscription.
    */
-  async cancelSubscription (subscriptionId, params = {}) {
-    const body = params['body']
+  async cancelSubscription (subscriptionId, options = {}) {
+    const body = options['body']
     let path = '/subscriptions/{subscription_id}/cancel'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, body, params)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -3106,8 +3135,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3119,19 +3149,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.type - Filter by type when:
+   * @param {string} options.params.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -3139,10 +3169,10 @@ class Client extends BaseClient {
    *
    * @return {Pager<Invoice>} A list of the subscription's invoices.
    */
-  listSubscriptionInvoices (subscriptionId, params = {}) {
+  listSubscriptionInvoices (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/invoices'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -3152,8 +3182,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3165,27 +3196,27 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.original - Filter by original field.
-   * @param {string} params.state - Filter by state field.
-   * @param {string} params.type - Filter by type field.
+   * @param {string} options.params.original - Filter by original field.
+   * @param {string} options.params.state - Filter by state field.
+   * @param {string} options.params.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the subscription's line items.
    */
-  listSubscriptionLineItems (subscriptionId, params = {}) {
+  listSubscriptionLineItems (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/line_items'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -3195,8 +3226,9 @@ class Client extends BaseClient {
    *
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3208,22 +3240,22 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on a subscription.
    */
-  listSubscriptionCouponRedemptions (subscriptionId, params = {}) {
+  listSubscriptionCouponRedemptions (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/coupon_redemptions'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**
@@ -3238,8 +3270,9 @@ class Client extends BaseClient {
    *   console.log(transaction.uuid)
    * }
    *
-   * @param {Object} params - The optional url parameters for this request.
-   * @param {Array.<string>} params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3251,26 +3284,26 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} params.limit - Limit number of records 1-200.
-   * @param {string} params.order - Sort order.
-   * @param {string} params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.params.limit - Limit number of records 1-200.
+   * @param {string} options.params.order - Sort order.
+   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.beginTime - Filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.params.endTime - Filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-   * @param {string} params.success - Filter by success field.
+   * @param {string} options.params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+   * @param {string} options.params.success - Filter by success field.
    * @return {Pager<Transaction>} A list of the site's transactions.
    */
-  listTransactions (params = {}) {
+  listTransactions (options = {}) {
     let path = '/transactions'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   /**


### PR DESCRIPTION
Updating the method parameter `params` to `options` to more accurate reflect what the intent of the parameter is. Also updates the incorrect doc comments to better clarify that `options.params` must be an object with individual url parameter keys within.

Resolves #97 