### PR TITLE
Updating doc comments to reflect that body is a key of 'options'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2432,7 +2432,7 @@ Read more about the security implications of parsing untrusted XML in <a href="h
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -2685,7 +2685,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -4233,7 +4233,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -4703,7 +4703,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -4904,7 +4904,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -5375,7 +5375,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -5744,7 +5744,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -6003,7 +6003,7 @@ returned at once you can sort the records yourself.</li>
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -6704,7 +6704,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -6936,7 +6936,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -7181,7 +7181,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -7428,7 +7428,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -7626,7 +7626,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -8207,7 +8207,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -8405,7 +8405,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -8672,7 +8672,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -8988,7 +8988,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -9737,7 +9737,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -10311,7 +10311,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -10326,9 +10326,10 @@ prevent some records from being returned.
 </td>
 </tr>
 
-  
-    <tr>
-  <td class='col-2 strong'>options.params.body</td>
+
+		
+		<tr>
+  <td class='col-2 strong'>options.body</td>
   <td class="col-2 quiet">
     InvoiceCollect
     
@@ -10336,9 +10337,6 @@ prevent some records from being returned.
   <td class='col-8'>The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
 </td>
 </tr>
-
-
-  
 
 
 		
@@ -10843,7 +10841,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -11094,7 +11092,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -11492,7 +11490,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -11928,7 +11926,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -12591,7 +12589,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -13206,7 +13204,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -13499,7 +13497,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -13780,7 +13778,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -14345,7 +14343,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -14500,7 +14498,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -14515,9 +14513,10 @@ prevent some records from being returned.
 </td>
 </tr>
 
-  
-    <tr>
-  <td class='col-2 strong'>options.params.body</td>
+
+		
+		<tr>
+  <td class='col-2 strong'>options.body</td>
   <td class="col-2 quiet">
     SubscriptionCancel
     
@@ -14525,9 +14524,6 @@ prevent some records from being returned.
   <td class='col-8'>The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
 </td>
 </tr>
-
-
-  
 
 
 		
@@ -15327,7 +15323,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -15560,7 +15556,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -15811,7 +15807,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		
@@ -15985,7 +15981,7 @@ prevent some records from being returned.
 				
 				= <code>{}</code>
 			</td>
-			<td class='col-6'>Optional configurations for the request (Currently only params is supported)
+			<td class='col-6'>Optional configurations for the request
 </td>
 		</tr>
 		

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -32,7 +32,7 @@ class Client extends BaseClient {
    *   console.log(site.subdomain)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -87,7 +87,7 @@ class Client extends BaseClient {
    *   console.log(account.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -519,7 +519,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -625,7 +625,7 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {number} options.params.limit - Limit number of records 1-200.
    * @param {string} options.params.order - Sort order.
@@ -654,7 +654,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -775,7 +775,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -861,7 +861,7 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -928,7 +928,7 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1107,7 +1107,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1154,7 +1154,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1197,7 +1197,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1242,7 +1242,7 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_account_acquisition}
    *
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1288,7 +1288,7 @@ class Client extends BaseClient {
    *   console.log(coupon.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1405,7 +1405,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1451,7 +1451,7 @@ class Client extends BaseClient {
    *   console.log(payment.uuid)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {number} options.params.limit - Limit number of records 1-200.
    * @param {string} options.params.order - Sort order.
@@ -1500,7 +1500,7 @@ class Client extends BaseClient {
    *   console.log(definition.displayName)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1577,7 +1577,7 @@ class Client extends BaseClient {
    *   console.log(item.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1789,7 +1789,7 @@ class Client extends BaseClient {
    *   console.log(invoice.number)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -1956,9 +1956,9 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
-   * @param {InvoiceCollect} options.params.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
+   * @param {InvoiceCollect} options.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
    * @return {Promise<Invoice>} The updated invoice.
    */
   async collectInvoice (invoiceId, options = {}) {
@@ -2081,7 +2081,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2125,7 +2125,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2228,7 +2228,7 @@ class Client extends BaseClient {
    *   console.log(`Item ${item.id} for ${item.amount}`)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2337,7 +2337,7 @@ class Client extends BaseClient {
    *   console.log(plan.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2513,7 +2513,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2619,7 +2619,7 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_add_ons}
    *
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2675,7 +2675,7 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_shipping_methods}
    *
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2736,7 +2736,7 @@ class Client extends BaseClient {
    *   console.log(subscription.uuid)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -2901,7 +2901,7 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {string} options.params.refund - The type of refund to perform:
    *
@@ -2943,9 +2943,9 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
-   * @param {SubscriptionCancel} options.params.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
+   * @param {SubscriptionCancel} options.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
    * @return {Promise<Subscription>} A canceled or failed subscription.
    */
   async cancelSubscription (subscriptionId, options = {}) {
@@ -3135,7 +3135,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -3182,7 +3182,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -3226,7 +3226,7 @@ class Client extends BaseClient {
    *
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
@@ -3270,7 +3270,7 @@ class Client extends BaseClient {
    *   console.log(transaction.uuid)
    * }
    *
-   * @param {Object} options - Optional configurations for the request (Currently only params is supported)
+   * @param {Object} options - Optional configurations for the request
    * @param {Object} options.params - The optional url parameters for this request.
    * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.


### PR DESCRIPTION
Followup to correct issues in #98 related to the `body` key of the `options` parameter