### PR TITLE
Validating options passed to _makeRequest

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -51,7 +51,7 @@ class BaseClient {
   _validateOptions (options) {
     Object.keys(options).forEach(key => {
       if (!ALLOWED_OPTIONS.includes(key)) {
-        throw new Error(`'${key}' is not a valid option`)
+        throw new ApiError(`'${key}' is not a valid option: [${ALLOWED_OPTIONS.join(', ')}]`)
       }
     })
   }

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -15,6 +15,7 @@ const BINARY_TYPES = [
   'application/pdf'
 ]
 const JSON_CONTENT_TYPE = 'application/json'
+const ALLOWED_OPTIONS = ['body', 'params']
 
 /**
  * This is the base functionality for the Recurly.Client.
@@ -47,7 +48,16 @@ class BaseClient {
     return path
   }
 
+  _validateOptions (options) {
+    Object.keys(options).forEach(key => {
+      if (!ALLOWED_OPTIONS.includes(key)) {
+        throw new Error(`'${key}' is not a valid option`)
+      }
+    })
+  }
+
   _makeRequest (method, path, body, options = {}) {
+    this._validateOptions(options)
     if (options.params && Object.keys(options.params).length > 0) {
       path = path + '?' + querystring.stringify(casters.castRequest(options.params))
     }

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -23,6 +23,7 @@ describe('BaseClient', () => {
       assert.equal(client._getDefaultOptions().headers['Accept'], 'application/vnd.recurly.v2022-01-01')
     })
   })
+
   describe('#_interpolatePath', () => {
     it('Should interpolate and encode the path with the given params', () => {
       const pathTmpl = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
@@ -32,6 +33,30 @@ describe('BaseClient', () => {
       })
 
       assert.equal(path, '/accounts/code-benjamin%20du%20monde/shipping_addresses/1234567890')
+    })
+  })
+
+  describe('#_makeRequest', () => {
+    beforeEach(() => {
+      client.mock((resp, options) => {
+        resp.status = 200
+        resp.body = JSON.stringify({ id: 'myid', object: 'my_resource' })
+        return Promise.resolve(resp)
+      })
+    })
+
+    it('Should throw an Error when invalid options are passed in', () => {
+      assert.throws(() => {
+        client._makeRequest('GET', '/resources/myid', null, { invalid: 'param' })
+      }, Error)
+    })
+
+    it('Should not throw an Error when semi-valid options are passed in', () => {
+      const resp = client._makeRequest('GET', '/resources/myid', null, { params: { invalid: 'param' } })
+      return resp
+        .then(resource => {
+          assert(resource instanceof MyResource)
+        })
     })
   })
 

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -48,7 +48,7 @@ describe('BaseClient', () => {
     it('Should throw an Error when invalid options are passed in', () => {
       assert.throws(() => {
         client._makeRequest('GET', '/resources/myid', null, { invalid: 'param' })
-      }, Error)
+      }, recurly.ApiError)
     })
 
     it('Should not throw an Error when semi-valid options are passed in', () => {


### PR DESCRIPTION
The optional `options` parameter of `_makeRequest` should only contain the keys `body` or `params` at present. 

This enhancement will validate that only those keys are passed in, as it is easy to accidentally populate query params directly on the `options` object instead of the `options.params` sub-object.