### PR TITLE
Fixing bugs in the Pager

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -126,7 +126,7 @@ class BaseClient {
     const jsonContent = (resp.contentType && resp.contentType.includes(JSON_CONTENT_TYPE))
 
     if (resp.status < 200 || resp.status > 299) {
-      if (jsonContent) {
+      if (jsonContent && resp.body) {
         const errBody = resp.body && JSON.parse(resp.body).error
         // If we have a body, we determine the error based on
         // the contents of the body

--- a/lib/recurly/Pager.js
+++ b/lib/recurly/Pager.js
@@ -37,7 +37,7 @@ class Pager {
    * @return {Number} The count of resources
    */
   async count () {
-    const empty = await this.client._makeRequest('HEAD', this.path, null, { params: this._consumeParams() })
+    const empty = await this.client._makeRequest('HEAD', this.path, null, { params: this.params })
     return empty.getResponse().recordCount
   }
 
@@ -49,9 +49,8 @@ class Pager {
    * @return {Object} The first resource in the list
    */
   async first () {
-    this.params = this.params || {}
-    this.params['limit'] = 1
-    let results = await this.client._makeRequest('GET', this.path, null, { params: this._consumeParams() })
+    const firstParams = Object.assign({}, this.params, { limit: 1 })
+    let results = await this.client._makeRequest('GET', this.path, null, { params: firstParams })
     return results.data && results.data[0]
   }
 


### PR DESCRIPTION
Resolves #105 

There are two bugs that are fixed here.

1. The error handling code was silently failing when a non-2XX response contained a `Content-Type: application/json` header but no body.
2. The `Pager` class was not sending the original params if the `count()` method was called prior to iteration.