### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -41,7 +41,28 @@ class BaseClient {
     this._requestAdapter = makeRequest
   }
 
+  _validatePathParameters (parameters) {
+    // Check to make sure that parameters are valid types
+    const invalidTypes = Object.keys(parameters).filter(name => {
+      return !['string', 'number', 'bigint'].includes(typeof parameters[name])
+    })
+    if (invalidTypes.length > 0) {
+      const issues = invalidTypes.map(name => {
+        return `'${name}:${parameters[name]}'`
+      })
+      throw new ApiError(`Invalid path parameters: ${issues.join(', ')}`)
+    }
+    // Check to make sure that parameters are not empty string values
+    const invalidStrings = Object.keys(parameters).filter(name => {
+      return typeof parameters[name] === 'string' && parameters[name].trim() === ''
+    })
+    if (invalidStrings.length > 0) {
+      throw new ApiError(`${invalidStrings.join(', ')} cannot be an empty string`)
+    }
+  }
+
   _interpolatePath (path, parameters = {}) {
+    this._validatePathParameters(parameters)
     Object.keys(parameters).forEach(name => {
       path = path.replace(`{${name}}`, encodeURIComponent(parameters[name].toString()))
     })

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -34,6 +34,26 @@ describe('BaseClient', () => {
 
       assert.equal(path, '/accounts/code-benjamin%20du%20monde/shipping_addresses/1234567890')
     })
+
+    it('Should validate that there are no empty string values', () => {
+      const pathTmpl = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
+      assert.throws(() => {
+        client._interpolatePath(pathTmpl, {
+          'account_id': '',
+          'shipping_address_id': 1234567890
+        })
+      }, recurly.ApiError)
+    })
+
+    it('Should validate that parameter values are valid types', () => {
+      const pathTmpl = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
+      assert.throws(() => {
+        client._interpolatePath(pathTmpl, {
+          'account_id': undefined,
+          'shipping_address_id': {}
+        })
+      }, recurly.ApiError)
+    })
   })
 
   describe('#_makeRequest', () => {


### PR DESCRIPTION
Adding a validation method that will ensure that path parameters are not empty strings to address issues where a `get_*` operation (`/resources/{resource_id}`) does not get handled by the API as a `list_*` operations (`/resources/`). The validation will also ensure that only approved types are used.