### PR TITLE
Use sha for 3rd party gh actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,8 @@ jobs:
 
     - name: Deploy
       if: success()
-      uses: crazy-max/ghaction-github-pages@v1
+      # use the specific sha of 3rd party libraries for security reasons https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+      uses: crazy-max/ghaction-github-pages@071043bf3d88171bec60f5089a7cbfd084d53c42
       with:
         target_branch: gh-pages
         build_dir: ./docs


### PR DESCRIPTION
https://julienrenaux.fr/2019/12/20/github-actions-security-risk/