### PR TITLE
Document request and response metadata

### DIFF
--- a/lib/recurly/Http.js
+++ b/lib/recurly/Http.js
@@ -83,6 +83,22 @@ function makeRequest (options, requestBody) {
   })
 }
 
+/**
+ * This class contains the metadata from the HTTP response
+ * from Recurly.
+ * @property {Request} request - The request responsible for this response.
+ * @property {Object} body - The parsed JSON response body.
+ * @property {number} statusCode - The HTTP status code.
+ * @property {string} contentType - The HTTP content type.
+ * @property {string} requestId - The unique id Recurly assigned to this request. Keep this for support.
+ * @property {number} rateLimit - The max rate limit.
+ * @property {number} rateLimitRemaining - The number of requests remaining until limit is reached.
+ * @property {Date} rateLimitReset - The datetime in which the rate limiter will be reset.
+ * @property {boolean} apiDeprecated - true if you are using a deprecated version of the API.
+ * @property {string} apiSunsetDate - The date in which this version will be sunset.
+ * @property {string} date - The date time from the server.
+ * @property {Object} proxyMetadata - Metadata from the proxy (e.g. cloudflare). Can be useful for debugging.
+ */
 class Response {
   static build (response, body, request) {
     const resp = new Response()
@@ -121,7 +137,16 @@ class Response {
   }
 }
 
+/**
+ * This class contains the metadata from the HTTP request
+ * sent to Recurly.
+ */
 class Request {
+  /**
+   * @param {string} method - The HTTP method of the request.
+   * @param {string} path - The path of the request.
+   * @param {Object} body - The JSON body of the request (optional).
+   */
   constructor (method, path, body = null) {
     this.method = method.toUpperCase()
     this.path = path

--- a/lib/recurly/Resource.js
+++ b/lib/recurly/Resource.js
@@ -22,6 +22,12 @@ class Resource {
     return this.getCompiledSchema().cast(v)
   }
 
+  /**
+   * This allows you to inspect the underlying HTTP metadata which
+   * created this resoource.
+   *
+   * @returns {Response} The underlying HTTP response.
+   */
   getResponse () {
     return this._response
   }


### PR DESCRIPTION
This ensures that the HTTP metadata objects are properly documented and show up in the generated docs.

![Screen Shot 2020-06-16 at 2 37 37 PM](https://user-images.githubusercontent.com/185919/84820577-7d1f6a00-afdf-11ea-8a3c-4898fdf18681.png)
![Screen Shot 2020-06-16 at 2 40 40 PM](https://user-images.githubusercontent.com/185919/84820585-7e509700-afdf-11ea-9c2b-01a7b0881b16.png)
