### PR TITLE
Explicity import resources rather than dynamic

### DIFF
--- a/lib/recurly/resources.js
+++ b/lib/recurly/resources.js
@@ -1,13 +1,6 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
-const resourcesPath = path.join(__dirname, 'resources')
-const exps = fs.readdirSync(resourcesPath).reduce((acc, file) => {
-  let className = file.split('/').reverse()[0].split('.')[0]
-  acc[className] = require(`./resources/${file}`)
-  return acc
-}, {})
+const exps = require('./resources/index')
 
 const Page = require('./Page')
 // Page has object type "list"

--- a/lib/recurly/resources/index.js
+++ b/lib/recurly/resources/index.js
@@ -1,0 +1,124 @@
+/* istanbul ignore file */
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+'use strict'
+
+module.exports.Site = require('./Site')
+
+module.exports.Address = require('./Address')
+
+module.exports.Settings = require('./Settings')
+
+module.exports.Error = require('./Error')
+
+module.exports.Account = require('./Account')
+
+module.exports.ShippingAddress = require('./ShippingAddress')
+
+module.exports.BillingInfo = require('./BillingInfo')
+
+module.exports.PaymentMethod = require('./PaymentMethod')
+
+module.exports.FraudInfo = require('./FraudInfo')
+
+module.exports.BillingInfoUpdatedBy = require('./BillingInfoUpdatedBy')
+
+module.exports.CustomField = require('./CustomField')
+
+module.exports.ErrorMayHaveTransaction = require('./ErrorMayHaveTransaction')
+
+module.exports.TransactionError = require('./TransactionError')
+
+module.exports.AccountAcquisition = require('./AccountAcquisition')
+
+module.exports.AccountAcquisitionCost = require('./AccountAcquisitionCost')
+
+module.exports.AccountMini = require('./AccountMini')
+
+module.exports.AccountBalance = require('./AccountBalance')
+
+module.exports.AccountBalanceAmount = require('./AccountBalanceAmount')
+
+module.exports.CouponRedemption = require('./CouponRedemption')
+
+module.exports.Coupon = require('./Coupon')
+
+module.exports.PlanMini = require('./PlanMini')
+
+module.exports.CouponDiscount = require('./CouponDiscount')
+
+module.exports.CouponDiscountPricing = require('./CouponDiscountPricing')
+
+module.exports.CouponDiscountTrial = require('./CouponDiscountTrial')
+
+module.exports.CreditPayment = require('./CreditPayment')
+
+module.exports.InvoiceMini = require('./InvoiceMini')
+
+module.exports.Transaction = require('./Transaction')
+
+module.exports.TransactionPaymentGateway = require('./TransactionPaymentGateway')
+
+module.exports.Invoice = require('./Invoice')
+
+module.exports.InvoiceAddress = require('./InvoiceAddress')
+
+module.exports.TaxInfo = require('./TaxInfo')
+
+module.exports.LineItemList = require('./LineItemList')
+
+module.exports.LineItem = require('./LineItem')
+
+module.exports.InvoiceCollection = require('./InvoiceCollection')
+
+module.exports.AccountNote = require('./AccountNote')
+
+module.exports.User = require('./User')
+
+module.exports.Subscription = require('./Subscription')
+
+module.exports.SubscriptionShipping = require('./SubscriptionShipping')
+
+module.exports.ShippingMethodMini = require('./ShippingMethodMini')
+
+module.exports.CouponRedemptionMini = require('./CouponRedemptionMini')
+
+module.exports.CouponMini = require('./CouponMini')
+
+module.exports.SubscriptionChange = require('./SubscriptionChange')
+
+module.exports.SubscriptionAddOn = require('./SubscriptionAddOn')
+
+module.exports.AddOnMini = require('./AddOnMini')
+
+module.exports.SubscriptionAddOnTier = require('./SubscriptionAddOnTier')
+
+module.exports.UniqueCouponCode = require('./UniqueCouponCode')
+
+module.exports.CustomFieldDefinition = require('./CustomFieldDefinition')
+
+module.exports.Item = require('./Item')
+
+module.exports.Pricing = require('./Pricing')
+
+module.exports.BinaryFile = require('./BinaryFile')
+
+module.exports.Plan = require('./Plan')
+
+module.exports.PlanPricing = require('./PlanPricing')
+
+module.exports.PlanHostedPages = require('./PlanHostedPages')
+
+module.exports.AddOn = require('./AddOn')
+
+module.exports.AddOnPricing = require('./AddOnPricing')
+
+module.exports.ItemMini = require('./ItemMini')
+
+module.exports.Tier = require('./Tier')
+
+module.exports.ShippingMethod = require('./ShippingMethod')

--- a/package-lock.json
+++ b/package-lock.json
@@ -3657,7 +3657,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3678,12 +3679,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3698,17 +3701,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3825,7 +3831,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3837,6 +3844,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3851,6 +3859,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3858,12 +3867,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3882,6 +3893,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3962,7 +3974,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3974,6 +3987,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4059,7 +4073,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4095,6 +4110,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4114,6 +4130,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4157,12 +4174,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Resolves #121

Instead of relying on using directory traversal to import resources,
let's generate an index file. This might make it simpler for alternative
import systems (e.g. webpack).