### PR TITLE
Release 3.8.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.8.0
+current_version = 3.8.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -15,7 +15,7 @@ Or manually insert the dependency into the `dependencies` section of your `packa
 ```
 {
   // ...
-  "recurly" : "^3.8.0"
+  "recurly" : "^3.8.1"
   // ...
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Recurly V3 node client",
   "main": "lib/recurly.js",
   "types": "lib/recurly.d.ts",


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-node/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.8.0...HEAD)

**Fixed bugs:**

- Serverless framework webpack scandir error? [\#121](https://github.com/recurly/recurly-client-node/issues/121)

**Merged pull requests:**

- Bump websocket-extensions from 0.1.3 to 0.1.4 [\#120](https://github.com/recurly/recurly-client-node/pull/120) ([dependabot[bot]](https://github.com/apps/dependabot))