### PR TITLE
Add support to specify custom headers

### DIFF
--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -15,7 +15,7 @@ const BINARY_TYPES = [
   'application/pdf'
 ]
 const JSON_CONTENT_TYPE = 'application/json'
-const ALLOWED_OPTIONS = ['body', 'params']
+const ALLOWED_OPTIONS = ['body', 'params', 'headers']
 
 /**
  * This is the base functionality for the Recurly.Client.
@@ -79,9 +79,8 @@ class BaseClient {
 
   _makeRequest (method, path, body, options = {}) {
     this._validateOptions(options)
-    const pathAndQuery = path + this._buildQuery(options)
 
-    const reqOptions = this._getDefaultOptions(method, pathAndQuery)
+    const reqOptions = this._getRequestOptions(method, path, options)
 
     return new Promise((resolve, reject) => {
       const httpReq = this._requestAdapter(reqOptions, body)
@@ -133,24 +132,24 @@ class BaseClient {
     return '?' + querystring.stringify(casters.castRequest(converted))
   }
 
-  _getDefaultOptions (method, path) {
+  _getRequestOptions (method, path, options) {
     // Create a copy to ensure that this._httpOptions is not modified
-    const options = Object.assign({}, this._httpOptions)
-    options.method = method
-    options.path = path
+    const reqOptions = Object.assign({}, this._httpOptions)
+    reqOptions.method = method
+    reqOptions.path = path + this._buildQuery(options)
 
     // The headers can't be stored in _httpOptions because this object will
     // be directly modified for certain requests. Object.assign() does not allow
     // for deep cloning
-    options.headers = {
+    reqOptions.headers = Object.assign({}, options.headers, {
       'Accept': `application/vnd.recurly.${this.apiVersion()}`,
       'User-Agent': `Recurly/${pkg.version}; node ${process.version}`,
       'Authorization': 'Basic ' + Buffer.from(this._getApiKey() + ':', 'ascii').toString('base64'),
       'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6',
       'Content-Type': 'application/json; charset=utf-8'
-    }
+    })
 
-    return options
+    return reqOptions
   }
 
   /**

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -70,10 +70,10 @@ class Client extends BaseClient {
    * @param {string} siteId - Site ID or subdomain. For ID no prefix is used e.g. `e28zov4fw0v2`. For subdomain use prefix `subdomain-`, e.g. `subdomain-recurly`.
    * @return {Promise<Site>} A site.
    */
-  async getSite (siteId) {
+  async getSite (siteId, options = {}) {
     let path = '/sites/{site_id}'
     path = this._interpolatePath(path, { 'site_id': siteId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -163,10 +163,10 @@ class Client extends BaseClient {
    * @param {AccountCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountCreate}
    * @return {Promise<Account>} An account.
    */
-  async createAccount (body) {
+  async createAccount (body, options = {}) {
     let path = '/accounts'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -193,10 +193,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
-  async getAccount (accountId) {
+  async getAccount (accountId, options = {}) {
     let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -228,10 +228,10 @@ class Client extends BaseClient {
    * @param {AccountUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountUpdate}
    * @return {Promise<Account>} An account.
    */
-  async updateAccount (accountId, body) {
+  async updateAccount (accountId, body, options = {}) {
     let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -257,10 +257,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
-  async deactivateAccount (accountId) {
+  async deactivateAccount (accountId, options = {}) {
     let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -287,10 +287,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<AccountAcquisition>} An account's acquisition data.
    */
-  async getAccountAcquisition (accountId) {
+  async getAccountAcquisition (accountId, options = {}) {
     let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -323,10 +323,10 @@ class Client extends BaseClient {
    * @param {AccountAcquisitionUpdatable} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountAcquisitionUpdatable}
    * @return {Promise<AccountAcquisition>} An account's updated acquisition data.
    */
-  async updateAccountAcquisition (accountId, body) {
+  async updateAccountAcquisition (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -353,10 +353,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Empty>} Acquisition data was succesfully deleted.
    */
-  async removeAccountAcquisition (accountId) {
+  async removeAccountAcquisition (accountId, options = {}) {
     let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -382,10 +382,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
-  async reactivateAccount (accountId) {
+  async reactivateAccount (accountId, options = {}) {
     let path = '/accounts/{account_id}/reactivate'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -412,10 +412,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<AccountBalance>} An account's balance.
    */
-  async getAccountBalance (accountId) {
+  async getAccountBalance (accountId, options = {}) {
     let path = '/accounts/{account_id}/balance'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -442,10 +442,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<BillingInfo>} An account's billing information.
    */
-  async getBillingInfo (accountId) {
+  async getBillingInfo (accountId, options = {}) {
     let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -477,10 +477,10 @@ class Client extends BaseClient {
    * @param {BillingInfoCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
    * @return {Promise<BillingInfo>} Updated billing information.
    */
-  async updateBillingInfo (accountId, body) {
+  async updateBillingInfo (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -507,10 +507,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Empty>} Billing information deleted
    */
-  async removeBillingInfo (accountId) {
+  async removeBillingInfo (accountId, options = {}) {
     let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -576,10 +576,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<CouponRedemption>} An active coupon redemption on an account.
    */
-  async getActiveCouponRedemption (accountId) {
+  async getActiveCouponRedemption (accountId, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -592,10 +592,10 @@ class Client extends BaseClient {
    * @param {CouponRedemptionCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponRedemptionCreate}
    * @return {Promise<CouponRedemption>} Returns the new coupon redemption.
    */
-  async createCouponRedemption (accountId, body) {
+  async createCouponRedemption (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -607,10 +607,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<CouponRedemption>} Coupon redemption deleted.
    */
-  async removeCouponRedemption (accountId) {
+  async removeCouponRedemption (accountId, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -726,10 +726,10 @@ class Client extends BaseClient {
    * @param {InvoiceCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices.
    */
-  async createInvoice (accountId, body) {
+  async createInvoice (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/invoices'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -763,10 +763,10 @@ class Client extends BaseClient {
    * @param {InvoiceCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the invoice previews.
    */
-  async previewInvoice (accountId, body) {
+  async previewInvoice (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/invoices/preview'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -843,10 +843,10 @@ class Client extends BaseClient {
    * @param {LineItemCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {LineItemCreate}
    * @return {Promise<LineItem>} Returns the new line item.
    */
-  async createLineItem (accountId, body) {
+  async createLineItem (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/line_items'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -910,10 +910,10 @@ class Client extends BaseClient {
    * @param {string} accountNoteId - Account Note ID.
    * @return {Promise<AccountNote>} An account note.
    */
-  async getAccountNote (accountId, accountNoteId) {
+  async getAccountNote (accountId, accountNoteId, options = {}) {
     let path = '/accounts/{account_id}/notes/{account_note_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'account_note_id': accountNoteId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -997,10 +997,10 @@ class Client extends BaseClient {
    * @param {ShippingAddressCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressCreate}
    * @return {Promise<ShippingAddress>} Returns the new shipping address.
    */
-  async createShippingAddress (accountId, body) {
+  async createShippingAddress (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -1028,10 +1028,10 @@ class Client extends BaseClient {
    * @param {string} shippingAddressId - Shipping Address ID.
    * @return {Promise<ShippingAddress>} A shipping address.
    */
-  async getShippingAddress (accountId, shippingAddressId) {
+  async getShippingAddress (accountId, shippingAddressId, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1064,10 +1064,10 @@ class Client extends BaseClient {
    * @param {ShippingAddressUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressUpdate}
    * @return {Promise<ShippingAddress>} The updated shipping address.
    */
-  async updateShippingAddress (accountId, shippingAddressId, body) {
+  async updateShippingAddress (accountId, shippingAddressId, body, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1095,10 +1095,10 @@ class Client extends BaseClient {
    * @param {string} shippingAddressId - Shipping Address ID.
    * @return {Promise<Empty>} Shipping address deleted.
    */
-  async removeShippingAddress (accountId, shippingAddressId) {
+  async removeShippingAddress (accountId, shippingAddressId, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -1332,10 +1332,10 @@ class Client extends BaseClient {
    * @param {CouponCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponCreate}
    * @return {Promise<Coupon>} A new coupon.
    */
-  async createCoupon (body) {
+  async createCoupon (body, options = {}) {
     let path = '/coupons'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -1362,10 +1362,10 @@ class Client extends BaseClient {
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
    * @return {Promise<Coupon>} A coupon.
    */
-  async getCoupon (couponId) {
+  async getCoupon (couponId, options = {}) {
     let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1378,10 +1378,10 @@ class Client extends BaseClient {
    * @param {CouponUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
    * @return {Promise<Coupon>} The updated coupon.
    */
-  async updateCoupon (couponId, body) {
+  async updateCoupon (couponId, body, options = {}) {
     let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1393,10 +1393,10 @@ class Client extends BaseClient {
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
    * @return {Promise<Coupon>} The expired Coupon
    */
-  async deactivateCoupon (couponId) {
+  async deactivateCoupon (couponId, options = {}) {
     let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -1483,10 +1483,10 @@ class Client extends BaseClient {
    * @param {string} creditPaymentId - Credit Payment ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<CreditPayment>} A credit payment.
    */
-  async getCreditPayment (creditPaymentId) {
+  async getCreditPayment (creditPaymentId, options = {}) {
     let path = '/credit_payments/{credit_payment_id}'
     path = this._interpolatePath(path, { 'credit_payment_id': creditPaymentId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1560,10 +1560,10 @@ class Client extends BaseClient {
    * @param {string} customFieldDefinitionId - Custom Field Definition ID
    * @return {Promise<CustomFieldDefinition>} An custom field definition.
    */
-  async getCustomFieldDefinition (customFieldDefinitionId) {
+  async getCustomFieldDefinition (customFieldDefinitionId, options = {}) {
     let path = '/custom_field_definitions/{custom_field_definition_id}'
     path = this._interpolatePath(path, { 'custom_field_definition_id': customFieldDefinitionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1649,10 +1649,10 @@ class Client extends BaseClient {
    * @param {ItemCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemCreate}
    * @return {Promise<Item>} A new item.
    */
-  async createItem (body) {
+  async createItem (body, options = {}) {
     let path = '/items'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -1679,10 +1679,10 @@ class Client extends BaseClient {
    * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
-  async getItem (itemId) {
+  async getItem (itemId, options = {}) {
     let path = '/items/{item_id}'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1714,10 +1714,10 @@ class Client extends BaseClient {
    * @param {ItemUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemUpdate}
    * @return {Promise<Item>} The updated item.
    */
-  async updateItem (itemId, body) {
+  async updateItem (itemId, body, options = {}) {
     let path = '/items/{item_id}'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1743,10 +1743,10 @@ class Client extends BaseClient {
    * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
-  async deactivateItem (itemId) {
+  async deactivateItem (itemId, options = {}) {
     let path = '/items/{item_id}'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -1772,10 +1772,10 @@ class Client extends BaseClient {
    * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
-  async reactivateItem (itemId) {
+  async reactivateItem (itemId, options = {}) {
     let path = '/items/{item_id}/reactivate'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -1854,10 +1854,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} An invoice.
    */
-  async getInvoice (invoiceId) {
+  async getInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1891,10 +1891,10 @@ class Client extends BaseClient {
    * @param {InvoiceUpdatable} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceUpdatable}
    * @return {Promise<Invoice>} An invoice.
    */
-  async putInvoice (invoiceId, body) {
+  async putInvoice (invoiceId, body, options = {}) {
     let path = '/invoices/{invoice_id}'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1929,10 +1929,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<BinaryFile>} An invoice as a PDF.
    */
-  async getInvoicePdf (invoiceId) {
+  async getInvoicePdf (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}.pdf'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1993,10 +1993,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async failInvoice (invoiceId) {
+  async failInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/mark_failed'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2024,10 +2024,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async markInvoiceSuccessful (invoiceId) {
+  async markInvoiceSuccessful (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/mark_successful'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2054,10 +2054,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async reopenInvoice (invoiceId) {
+  async reopenInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/reopen'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2069,10 +2069,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async voidInvoice (invoiceId) {
+  async voidInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/void'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2085,10 +2085,10 @@ class Client extends BaseClient {
    * @param {ExternalTransaction} body - The object representing the JSON request to send to the server. It should conform to the schema of {ExternalTransaction}
    * @return {Promise<Transaction>} The recorded transaction.
    */
-  async recordExternalTransaction (invoiceId, body) {
+  async recordExternalTransaction (invoiceId, body, options = {}) {
     let path = '/invoices/{invoice_id}/transactions'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2227,10 +2227,10 @@ class Client extends BaseClient {
    * @param {InvoiceRefund} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceRefund}
    * @return {Promise<Invoice>} Returns the new credit invoice.
    */
-  async refundInvoice (invoiceId, body) {
+  async refundInvoice (invoiceId, body, options = {}) {
     let path = '/invoices/{invoice_id}/refund'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2306,10 +2306,10 @@ class Client extends BaseClient {
    * @param {string} lineItemId - Line Item ID.
    * @return {Promise<LineItem>} A line item.
    */
-  async getLineItem (lineItemId) {
+  async getLineItem (lineItemId, options = {}) {
     let path = '/line_items/{line_item_id}'
     path = this._interpolatePath(path, { 'line_item_id': lineItemId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2336,10 +2336,10 @@ class Client extends BaseClient {
    * @param {string} lineItemId - Line Item ID.
    * @return {Promise<Empty>} Line item deleted.
    */
-  async removeLineItem (lineItemId) {
+  async removeLineItem (lineItemId, options = {}) {
     let path = '/line_items/{line_item_id}'
     path = this._interpolatePath(path, { 'line_item_id': lineItemId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2423,10 +2423,10 @@ class Client extends BaseClient {
    * @param {PlanCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanCreate}
    * @return {Promise<Plan>} A plan.
    */
-  async createPlan (body) {
+  async createPlan (body, options = {}) {
     let path = '/plans'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2453,10 +2453,10 @@ class Client extends BaseClient {
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<Plan>} A plan.
    */
-  async getPlan (planId) {
+  async getPlan (planId, options = {}) {
     let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2487,10 +2487,10 @@ class Client extends BaseClient {
    * @param {PlanUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanUpdate}
    * @return {Promise<Plan>} A plan.
    */
-  async updatePlan (planId, body) {
+  async updatePlan (planId, body, options = {}) {
     let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2517,10 +2517,10 @@ class Client extends BaseClient {
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<Plan>} Plan deleted
    */
-  async removePlan (planId) {
+  async removePlan (planId, options = {}) {
     let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2575,10 +2575,10 @@ class Client extends BaseClient {
    * @param {AddOnCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnCreate}
    * @return {Promise<AddOn>} An add-on.
    */
-  async createPlanAddOn (planId, body) {
+  async createPlanAddOn (planId, body, options = {}) {
     let path = '/plans/{plan_id}/add_ons'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2591,10 +2591,10 @@ class Client extends BaseClient {
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} An add-on.
    */
-  async getPlanAddOn (planId, addOnId) {
+  async getPlanAddOn (planId, addOnId, options = {}) {
     let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2608,10 +2608,10 @@ class Client extends BaseClient {
    * @param {AddOnUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnUpdate}
    * @return {Promise<AddOn>} An add-on.
    */
-  async updatePlanAddOn (planId, addOnId, body) {
+  async updatePlanAddOn (planId, addOnId, body, options = {}) {
     let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2624,10 +2624,10 @@ class Client extends BaseClient {
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} Add-on deleted
    */
-  async removePlanAddOn (planId, addOnId) {
+  async removePlanAddOn (planId, addOnId, options = {}) {
     let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2680,10 +2680,10 @@ class Client extends BaseClient {
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} An add-on.
    */
-  async getAddOn (addOnId) {
+  async getAddOn (addOnId, options = {}) {
     let path = '/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'add_on_id': addOnId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2735,10 +2735,10 @@ class Client extends BaseClient {
    * @param {ShippingMethodCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodCreate}
    * @return {Promise<ShippingMethod>} A new shipping method.
    */
-  async createShippingMethod (body) {
+  async createShippingMethod (body, options = {}) {
     let path = '/shipping_methods'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2750,10 +2750,10 @@ class Client extends BaseClient {
    * @param {string} shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
    * @return {Promise<ShippingMethod>} A shipping method.
    */
-  async getShippingMethod (shippingMethodId) {
+  async getShippingMethod (shippingMethodId, options = {}) {
     let path = '/shipping_methods/{shipping_method_id}'
     path = this._interpolatePath(path, { 'shipping_method_id': shippingMethodId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2766,10 +2766,10 @@ class Client extends BaseClient {
    * @param {ShippingMethodUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodUpdate}
    * @return {Promise<ShippingMethod>} The updated shipping method.
    */
-  async updateShippingMethod (shippingMethodId, body) {
+  async updateShippingMethod (shippingMethodId, body, options = {}) {
     let path = '/shipping_methods/{shipping_method_id}'
     path = this._interpolatePath(path, { 'shipping_method_id': shippingMethodId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2781,10 +2781,10 @@ class Client extends BaseClient {
    * @param {string} shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
    * @return {Promise<ShippingMethod>} A shipping method.
    */
-  async deactivateShippingMethod (shippingMethodId) {
+  async deactivateShippingMethod (shippingMethodId, options = {}) {
     let path = '/shipping_methods/{shipping_method_id}'
     path = this._interpolatePath(path, { 'shipping_method_id': shippingMethodId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2870,10 +2870,10 @@ class Client extends BaseClient {
    * @param {SubscriptionCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCreate}
    * @return {Promise<Subscription>} A subscription.
    */
-  async createSubscription (body) {
+  async createSubscription (body, options = {}) {
     let path = '/subscriptions'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2900,10 +2900,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
-  async getSubscription (subscriptionId) {
+  async getSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2936,10 +2936,10 @@ class Client extends BaseClient {
    * @param {SubscriptionUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionUpdate}
    * @return {Promise<Subscription>} A subscription.
    */
-  async modifySubscription (subscriptionId, body) {
+  async modifySubscription (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -3043,10 +3043,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} An active subscription.
    */
-  async reactivateSubscription (subscriptionId) {
+  async reactivateSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/reactivate'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3059,10 +3059,10 @@ class Client extends BaseClient {
    * @param {SubscriptionPause} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionPause}
    * @return {Promise<Subscription>} A subscription.
    */
-  async pauseSubscription (subscriptionId, body) {
+  async pauseSubscription (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}/pause'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -3074,10 +3074,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
-  async resumeSubscription (subscriptionId) {
+  async resumeSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/resume'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3089,10 +3089,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
-  async convertTrial (subscriptionId) {
+  async convertTrial (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/convert_trial'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3119,10 +3119,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<SubscriptionChange>} A subscription's pending change.
    */
-  async getSubscriptionChange (subscriptionId) {
+  async getSubscriptionChange (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3155,10 +3155,10 @@ class Client extends BaseClient {
    * @param {SubscriptionChangeCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChange>} A subscription change.
    */
-  async createSubscriptionChange (subscriptionId, body) {
+  async createSubscriptionChange (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3185,10 +3185,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Empty>} Subscription change was deleted.
    */
-  async removeSubscriptionChange (subscriptionId) {
+  async removeSubscriptionChange (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -3201,10 +3201,10 @@ class Client extends BaseClient {
    * @param {SubscriptionChangeCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChangePreview>} A subscription change.
    */
-  async previewSubscriptionChange (subscriptionId, body) {
+  async previewSubscriptionChange (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}/change/preview'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3409,10 +3409,10 @@ class Client extends BaseClient {
    * @param {string} transactionId - Transaction ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Transaction>} A transaction.
    */
-  async getTransaction (transactionId) {
+  async getTransaction (transactionId, options = {}) {
     let path = '/transactions/{transaction_id}'
     path = this._interpolatePath(path, { 'transaction_id': transactionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3424,10 +3424,10 @@ class Client extends BaseClient {
    * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
-  async getUniqueCouponCode (uniqueCouponCodeId) {
+  async getUniqueCouponCode (uniqueCouponCodeId, options = {}) {
     let path = '/unique_coupon_codes/{unique_coupon_code_id}'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3439,10 +3439,10 @@ class Client extends BaseClient {
    * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
-  async deactivateUniqueCouponCode (uniqueCouponCodeId) {
+  async deactivateUniqueCouponCode (uniqueCouponCodeId, options = {}) {
     let path = '/unique_coupon_codes/{unique_coupon_code_id}'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -3454,10 +3454,10 @@ class Client extends BaseClient {
    * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
-  async reactivateUniqueCouponCode (uniqueCouponCodeId) {
+  async reactivateUniqueCouponCode (uniqueCouponCodeId, options = {}) {
     let path = '/unique_coupon_codes/{unique_coupon_code_id}/restore'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3499,10 +3499,10 @@ class Client extends BaseClient {
    * @param {PurchaseCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices
    */
-  async createPurchase (body) {
+  async createPurchase (body, options = {}) {
     let path = '/purchases'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3544,10 +3544,10 @@ class Client extends BaseClient {
    * @param {PurchaseCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns preview of the new invoices
    */
-  async previewPurchase (body) {
+  async previewPurchase (body, options = {}) {
     let path = '/purchases/preview'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 }
 

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -17,10 +17,10 @@ describe('BaseClient', () => {
 
   describe('#constructor', () => {
     it('Should set the internal state and headers', () => {
-      assert.equal(client._getDefaultOptions().headers['Authorization'], 'Basic bXlhcGlrZXk6')
+      assert.equal(client._getRequestOptions('GET', '/resources', {}).headers['Authorization'], 'Basic bXlhcGlrZXk6')
       const userAgentRegex = /^Recurly\/\d+(\.\d+){0,2}; node v\d+(\.\d+){0,2}.*$/
-      assert.ok(userAgentRegex.test(client._getDefaultOptions().headers['User-Agent']))
-      assert.equal(client._getDefaultOptions().headers['Accept'], 'application/vnd.recurly.v2022-01-01')
+      assert.ok(userAgentRegex.test(client._getRequestOptions('GET', '/resources', {}).headers['User-Agent']))
+      assert.equal(client._getRequestOptions('GET', '/resources', {}).headers['Accept'], 'application/vnd.recurly.v2022-01-01')
     })
   })
 


### PR DESCRIPTION
This will allow the user to specify custom headers that will be included in individual requests.

```node
const accountCreate = {
  ...
}
const options = {
  headers: { 'Accept-Language': 'fr' }
}
const account = await client.createAccount(accountCreate, options)
```

Due to the fact that this is a breaking change, the enhancement will be published with the `4.x` client.