### PR TITLE
Adding hierarchical errors

### DIFF
--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -85,10 +85,10 @@ class Client extends BaseClient {
    * @param {string} siteId - Site ID or subdomain. For ID no prefix is used e.g. `e28zov4fw0v2`. For subdomain use prefix `subdomain-`, e.g. `subdomain-recurly`.
    * @return {Promise<Site>} A site.
    */
-  async getSite (siteId) {
+  async getSite (siteId, options = {}) {
     let path = '/sites/{site_id}'
     path = this._interpolatePath(path, { 'site_id': siteId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -178,10 +178,10 @@ class Client extends BaseClient {
    * @param {AccountCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountCreate}
    * @return {Promise<Account>} An account.
    */
-  async createAccount (body) {
+  async createAccount (body, options = {}) {
     let path = '/accounts'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -208,10 +208,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
-  async getAccount (accountId) {
+  async getAccount (accountId, options = {}) {
     let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -243,10 +243,10 @@ class Client extends BaseClient {
    * @param {AccountUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountUpdate}
    * @return {Promise<Account>} An account.
    */
-  async updateAccount (accountId, body) {
+  async updateAccount (accountId, body, options = {}) {
     let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -272,10 +272,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
-  async deactivateAccount (accountId) {
+  async deactivateAccount (accountId, options = {}) {
     let path = '/accounts/{account_id}'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -302,10 +302,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<AccountAcquisition>} An account's acquisition data.
    */
-  async getAccountAcquisition (accountId) {
+  async getAccountAcquisition (accountId, options = {}) {
     let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -338,10 +338,10 @@ class Client extends BaseClient {
    * @param {AccountAcquisitionUpdatable} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountAcquisitionUpdatable}
    * @return {Promise<AccountAcquisition>} An account's updated acquisition data.
    */
-  async updateAccountAcquisition (accountId, body) {
+  async updateAccountAcquisition (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -368,10 +368,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Empty>} Acquisition data was succesfully deleted.
    */
-  async removeAccountAcquisition (accountId) {
+  async removeAccountAcquisition (accountId, options = {}) {
     let path = '/accounts/{account_id}/acquisition'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -397,10 +397,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
-  async reactivateAccount (accountId) {
+  async reactivateAccount (accountId, options = {}) {
     let path = '/accounts/{account_id}/reactivate'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -427,10 +427,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<AccountBalance>} An account's balance.
    */
-  async getAccountBalance (accountId) {
+  async getAccountBalance (accountId, options = {}) {
     let path = '/accounts/{account_id}/balance'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -457,10 +457,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<BillingInfo>} An account's billing information.
    */
-  async getBillingInfo (accountId) {
+  async getBillingInfo (accountId, options = {}) {
     let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -492,10 +492,10 @@ class Client extends BaseClient {
    * @param {BillingInfoCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
    * @return {Promise<BillingInfo>} Updated billing information.
    */
-  async updateBillingInfo (accountId, body) {
+  async updateBillingInfo (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -522,10 +522,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Empty>} Billing information deleted
    */
-  async removeBillingInfo (accountId) {
+  async removeBillingInfo (accountId, options = {}) {
     let path = '/accounts/{account_id}/billing_info'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -597,10 +597,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<CouponRedemption>} An active coupon redemption on an account.
    */
-  async getActiveCouponRedemption (accountId) {
+  async getActiveCouponRedemption (accountId, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -613,10 +613,10 @@ class Client extends BaseClient {
    * @param {CouponRedemptionCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponRedemptionCreate}
    * @return {Promise<CouponRedemption>} Returns the new coupon redemption.
    */
-  async createCouponRedemption (accountId, body) {
+  async createCouponRedemption (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -643,10 +643,10 @@ class Client extends BaseClient {
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<CouponRedemption>} Coupon redemption deleted.
    */
-  async removeCouponRedemption (accountId) {
+  async removeCouponRedemption (accountId, options = {}) {
     let path = '/accounts/{account_id}/coupon_redemptions/active'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -768,10 +768,10 @@ class Client extends BaseClient {
    * @param {InvoiceCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices.
    */
-  async createInvoice (accountId, body) {
+  async createInvoice (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/invoices'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -805,10 +805,10 @@ class Client extends BaseClient {
    * @param {InvoiceCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the invoice previews.
    */
-  async previewInvoice (accountId, body) {
+  async previewInvoice (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/invoices/preview'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -891,10 +891,10 @@ class Client extends BaseClient {
    * @param {LineItemCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {LineItemCreate}
    * @return {Promise<LineItem>} Returns the new line item.
    */
-  async createLineItem (accountId, body) {
+  async createLineItem (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/line_items'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -958,10 +958,10 @@ class Client extends BaseClient {
    * @param {string} accountNoteId - Account Note ID.
    * @return {Promise<AccountNote>} An account note.
    */
-  async getAccountNote (accountId, accountNoteId) {
+  async getAccountNote (accountId, accountNoteId, options = {}) {
     let path = '/accounts/{account_id}/notes/{account_note_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'account_note_id': accountNoteId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1045,10 +1045,10 @@ class Client extends BaseClient {
    * @param {ShippingAddressCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressCreate}
    * @return {Promise<ShippingAddress>} Returns the new shipping address.
    */
-  async createShippingAddress (accountId, body) {
+  async createShippingAddress (accountId, body, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses'
     path = this._interpolatePath(path, { 'account_id': accountId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -1076,10 +1076,10 @@ class Client extends BaseClient {
    * @param {string} shippingAddressId - Shipping Address ID.
    * @return {Promise<ShippingAddress>} A shipping address.
    */
-  async getShippingAddress (accountId, shippingAddressId) {
+  async getShippingAddress (accountId, shippingAddressId, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1112,10 +1112,10 @@ class Client extends BaseClient {
    * @param {ShippingAddressUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressUpdate}
    * @return {Promise<ShippingAddress>} The updated shipping address.
    */
-  async updateShippingAddress (accountId, shippingAddressId, body) {
+  async updateShippingAddress (accountId, shippingAddressId, body, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1143,10 +1143,10 @@ class Client extends BaseClient {
    * @param {string} shippingAddressId - Shipping Address ID.
    * @return {Promise<Empty>} Shipping address deleted.
    */
-  async removeShippingAddress (accountId, shippingAddressId) {
+  async removeShippingAddress (accountId, shippingAddressId, options = {}) {
     let path = '/accounts/{account_id}/shipping_addresses/{shipping_address_id}'
     path = this._interpolatePath(path, { 'account_id': accountId, 'shipping_address_id': shippingAddressId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -1419,10 +1419,10 @@ class Client extends BaseClient {
    * @param {CouponCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponCreate}
    * @return {Promise<Coupon>} A new coupon.
    */
-  async createCoupon (body) {
+  async createCoupon (body, options = {}) {
     let path = '/coupons'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -1449,10 +1449,10 @@ class Client extends BaseClient {
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
    * @return {Promise<Coupon>} A coupon.
    */
-  async getCoupon (couponId) {
+  async getCoupon (couponId, options = {}) {
     let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1483,10 +1483,10 @@ class Client extends BaseClient {
    * @param {CouponUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
    * @return {Promise<Coupon>} The updated coupon.
    */
-  async updateCoupon (couponId, body) {
+  async updateCoupon (couponId, body, options = {}) {
     let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1513,10 +1513,10 @@ class Client extends BaseClient {
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
    * @return {Promise<Coupon>} The expired Coupon
    */
-  async deactivateCoupon (couponId) {
+  async deactivateCoupon (couponId, options = {}) {
     let path = '/coupons/{coupon_id}'
     path = this._interpolatePath(path, { 'coupon_id': couponId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -1603,10 +1603,10 @@ class Client extends BaseClient {
    * @param {string} creditPaymentId - Credit Payment ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<CreditPayment>} A credit payment.
    */
-  async getCreditPayment (creditPaymentId) {
+  async getCreditPayment (creditPaymentId, options = {}) {
     let path = '/credit_payments/{credit_payment_id}'
     path = this._interpolatePath(path, { 'credit_payment_id': creditPaymentId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1680,10 +1680,10 @@ class Client extends BaseClient {
    * @param {string} customFieldDefinitionId - Custom Field Definition ID
    * @return {Promise<CustomFieldDefinition>} An custom field definition.
    */
-  async getCustomFieldDefinition (customFieldDefinitionId) {
+  async getCustomFieldDefinition (customFieldDefinitionId, options = {}) {
     let path = '/custom_field_definitions/{custom_field_definition_id}'
     path = this._interpolatePath(path, { 'custom_field_definition_id': customFieldDefinitionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1769,10 +1769,10 @@ class Client extends BaseClient {
    * @param {ItemCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemCreate}
    * @return {Promise<Item>} A new item.
    */
-  async createItem (body) {
+  async createItem (body, options = {}) {
     let path = '/items'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -1799,10 +1799,10 @@ class Client extends BaseClient {
    * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
-  async getItem (itemId) {
+  async getItem (itemId, options = {}) {
     let path = '/items/{item_id}'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -1834,10 +1834,10 @@ class Client extends BaseClient {
    * @param {ItemUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemUpdate}
    * @return {Promise<Item>} The updated item.
    */
-  async updateItem (itemId, body) {
+  async updateItem (itemId, body, options = {}) {
     let path = '/items/{item_id}'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -1863,10 +1863,10 @@ class Client extends BaseClient {
    * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
-  async deactivateItem (itemId) {
+  async deactivateItem (itemId, options = {}) {
     let path = '/items/{item_id}'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -1892,10 +1892,10 @@ class Client extends BaseClient {
    * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
-  async reactivateItem (itemId) {
+  async reactivateItem (itemId, options = {}) {
     let path = '/items/{item_id}/reactivate'
     path = this._interpolatePath(path, { 'item_id': itemId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -1974,10 +1974,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} An invoice.
    */
-  async getInvoice (invoiceId) {
+  async getInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2011,10 +2011,10 @@ class Client extends BaseClient {
    * @param {InvoiceUpdatable} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceUpdatable}
    * @return {Promise<Invoice>} An invoice.
    */
-  async putInvoice (invoiceId, body) {
+  async putInvoice (invoiceId, body, options = {}) {
     let path = '/invoices/{invoice_id}'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2049,10 +2049,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<BinaryFile>} An invoice as a PDF.
    */
-  async getInvoicePdf (invoiceId) {
+  async getInvoicePdf (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}.pdf'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2113,10 +2113,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async failInvoice (invoiceId) {
+  async failInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/mark_failed'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2144,10 +2144,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async markInvoiceSuccessful (invoiceId) {
+  async markInvoiceSuccessful (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/mark_successful'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2174,10 +2174,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async reopenInvoice (invoiceId) {
+  async reopenInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/reopen'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2204,10 +2204,10 @@ class Client extends BaseClient {
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
-  async voidInvoice (invoiceId) {
+  async voidInvoice (invoiceId, options = {}) {
     let path = '/invoices/{invoice_id}/void'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -2240,10 +2240,10 @@ class Client extends BaseClient {
    * @param {ExternalTransaction} body - The object representing the JSON request to send to the server. It should conform to the schema of {ExternalTransaction}
    * @return {Promise<Transaction>} The recorded transaction.
    */
-  async recordExternalTransaction (invoiceId, body) {
+  async recordExternalTransaction (invoiceId, body, options = {}) {
     let path = '/invoices/{invoice_id}/transactions'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2394,10 +2394,10 @@ class Client extends BaseClient {
    * @param {InvoiceRefund} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceRefund}
    * @return {Promise<Invoice>} Returns the new credit invoice.
    */
-  async refundInvoice (invoiceId, body) {
+  async refundInvoice (invoiceId, body, options = {}) {
     let path = '/invoices/{invoice_id}/refund'
     path = this._interpolatePath(path, { 'invoice_id': invoiceId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2473,10 +2473,10 @@ class Client extends BaseClient {
    * @param {string} lineItemId - Line Item ID.
    * @return {Promise<LineItem>} A line item.
    */
-  async getLineItem (lineItemId) {
+  async getLineItem (lineItemId, options = {}) {
     let path = '/line_items/{line_item_id}'
     path = this._interpolatePath(path, { 'line_item_id': lineItemId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2503,10 +2503,10 @@ class Client extends BaseClient {
    * @param {string} lineItemId - Line Item ID.
    * @return {Promise<Empty>} Line item deleted.
    */
-  async removeLineItem (lineItemId) {
+  async removeLineItem (lineItemId, options = {}) {
     let path = '/line_items/{line_item_id}'
     path = this._interpolatePath(path, { 'line_item_id': lineItemId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2590,10 +2590,10 @@ class Client extends BaseClient {
    * @param {PlanCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanCreate}
    * @return {Promise<Plan>} A plan.
    */
-  async createPlan (body) {
+  async createPlan (body, options = {}) {
     let path = '/plans'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2620,10 +2620,10 @@ class Client extends BaseClient {
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<Plan>} A plan.
    */
-  async getPlan (planId) {
+  async getPlan (planId, options = {}) {
     let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2654,10 +2654,10 @@ class Client extends BaseClient {
    * @param {PlanUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanUpdate}
    * @return {Promise<Plan>} A plan.
    */
-  async updatePlan (planId, body) {
+  async updatePlan (planId, body, options = {}) {
     let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2684,10 +2684,10 @@ class Client extends BaseClient {
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<Plan>} Plan deleted
    */
-  async removePlan (planId) {
+  async removePlan (planId, options = {}) {
     let path = '/plans/{plan_id}'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2775,10 +2775,10 @@ class Client extends BaseClient {
    * @param {AddOnCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnCreate}
    * @return {Promise<AddOn>} An add-on.
    */
-  async createPlanAddOn (planId, body) {
+  async createPlanAddOn (planId, body, options = {}) {
     let path = '/plans/{plan_id}/add_ons'
     path = this._interpolatePath(path, { 'plan_id': planId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -2806,10 +2806,10 @@ class Client extends BaseClient {
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} An add-on.
    */
-  async getPlanAddOn (planId, addOnId) {
+  async getPlanAddOn (planId, addOnId, options = {}) {
     let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -2841,10 +2841,10 @@ class Client extends BaseClient {
    * @param {AddOnUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnUpdate}
    * @return {Promise<AddOn>} An add-on.
    */
-  async updatePlanAddOn (planId, addOnId, body) {
+  async updatePlanAddOn (planId, addOnId, body, options = {}) {
     let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -2872,10 +2872,10 @@ class Client extends BaseClient {
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} Add-on deleted
    */
-  async removePlanAddOn (planId, addOnId) {
+  async removePlanAddOn (planId, addOnId, options = {}) {
     let path = '/plans/{plan_id}/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'plan_id': planId, 'add_on_id': addOnId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -2949,10 +2949,10 @@ class Client extends BaseClient {
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} An add-on.
    */
-  async getAddOn (addOnId) {
+  async getAddOn (addOnId, options = {}) {
     let path = '/add_ons/{add_on_id}'
     path = this._interpolatePath(path, { 'add_on_id': addOnId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3010,10 +3010,10 @@ class Client extends BaseClient {
    * @param {ShippingMethodCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodCreate}
    * @return {Promise<ShippingMethod>} A new shipping method.
    */
-  async createShippingMethod (body) {
+  async createShippingMethod (body, options = {}) {
     let path = '/shipping_methods'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3025,10 +3025,10 @@ class Client extends BaseClient {
    * @param {string} id - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
    * @return {Promise<ShippingMethod>} A shipping method.
    */
-  async getShippingMethod (id) {
+  async getShippingMethod (id, options = {}) {
     let path = '/shipping_methods/{id}'
     path = this._interpolatePath(path, { 'id': id })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3041,10 +3041,10 @@ class Client extends BaseClient {
    * @param {ShippingMethodUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodUpdate}
    * @return {Promise<ShippingMethod>} The updated shipping method.
    */
-  async updateShippingMethod (shippingMethodId, body) {
+  async updateShippingMethod (shippingMethodId, body, options = {}) {
     let path = '/shipping_methods/{shipping_method_id}'
     path = this._interpolatePath(path, { 'shipping_method_id': shippingMethodId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -3056,10 +3056,10 @@ class Client extends BaseClient {
    * @param {string} shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
    * @return {Promise<ShippingMethod>} A shipping method.
    */
-  async deactivateShippingMethod (shippingMethodId) {
+  async deactivateShippingMethod (shippingMethodId, options = {}) {
     let path = '/shipping_methods/{shipping_method_id}'
     path = this._interpolatePath(path, { 'shipping_method_id': shippingMethodId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -3145,10 +3145,10 @@ class Client extends BaseClient {
    * @param {SubscriptionCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCreate}
    * @return {Promise<Subscription>} A subscription.
    */
-  async createSubscription (body) {
+  async createSubscription (body, options = {}) {
     let path = '/subscriptions'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3175,10 +3175,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
-  async getSubscription (subscriptionId) {
+  async getSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3211,10 +3211,10 @@ class Client extends BaseClient {
    * @param {SubscriptionUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionUpdate}
    * @return {Promise<Subscription>} A subscription.
    */
-  async modifySubscription (subscriptionId, body) {
+  async modifySubscription (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -3318,10 +3318,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} An active subscription.
    */
-  async reactivateSubscription (subscriptionId) {
+  async reactivateSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/reactivate'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3352,10 +3352,10 @@ class Client extends BaseClient {
    * @param {SubscriptionPause} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionPause}
    * @return {Promise<Subscription>} A subscription.
    */
-  async pauseSubscription (subscriptionId, body) {
+  async pauseSubscription (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}/pause'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, body)
+    return this._makeRequest('PUT', path, body, options)
   }
 
   /**
@@ -3382,10 +3382,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
-  async resumeSubscription (subscriptionId) {
+  async resumeSubscription (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/resume'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3397,10 +3397,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
-  async convertTrial (subscriptionId) {
+  async convertTrial (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/convert_trial'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3427,10 +3427,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<SubscriptionChange>} A subscription's pending change.
    */
-  async getSubscriptionChange (subscriptionId) {
+  async getSubscriptionChange (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3463,10 +3463,10 @@ class Client extends BaseClient {
    * @param {SubscriptionChangeCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChange>} A subscription change.
    */
-  async createSubscriptionChange (subscriptionId, body) {
+  async createSubscriptionChange (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3493,10 +3493,10 @@ class Client extends BaseClient {
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Empty>} Subscription change was deleted.
    */
-  async removeSubscriptionChange (subscriptionId) {
+  async removeSubscriptionChange (subscriptionId, options = {}) {
     let path = '/subscriptions/{subscription_id}/change'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -3509,10 +3509,10 @@ class Client extends BaseClient {
    * @param {SubscriptionChangeCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChangePreview>} A subscription change.
    */
-  async previewSubscriptionChange (subscriptionId, body) {
+  async previewSubscriptionChange (subscriptionId, body, options = {}) {
     let path = '/subscriptions/{subscription_id}/change/preview'
     path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3735,10 +3735,10 @@ class Client extends BaseClient {
    * @param {string} transactionId - Transaction ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Transaction>} A transaction.
    */
-  async getTransaction (transactionId) {
+  async getTransaction (transactionId, options = {}) {
     let path = '/transactions/{transaction_id}'
     path = this._interpolatePath(path, { 'transaction_id': transactionId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3750,10 +3750,10 @@ class Client extends BaseClient {
    * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
-  async getUniqueCouponCode (uniqueCouponCodeId) {
+  async getUniqueCouponCode (uniqueCouponCodeId, options = {}) {
     let path = '/unique_coupon_codes/{unique_coupon_code_id}'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
-    return this._makeRequest('GET', path, null)
+    return this._makeRequest('GET', path, null, options)
   }
 
   /**
@@ -3765,10 +3765,10 @@ class Client extends BaseClient {
    * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
-  async deactivateUniqueCouponCode (uniqueCouponCodeId) {
+  async deactivateUniqueCouponCode (uniqueCouponCodeId, options = {}) {
     let path = '/unique_coupon_codes/{unique_coupon_code_id}'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
-    return this._makeRequest('DELETE', path, null)
+    return this._makeRequest('DELETE', path, null, options)
   }
 
   /**
@@ -3780,10 +3780,10 @@ class Client extends BaseClient {
    * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
-  async reactivateUniqueCouponCode (uniqueCouponCodeId) {
+  async reactivateUniqueCouponCode (uniqueCouponCodeId, options = {}) {
     let path = '/unique_coupon_codes/{unique_coupon_code_id}/restore'
     path = this._interpolatePath(path, { 'unique_coupon_code_id': uniqueCouponCodeId })
-    return this._makeRequest('PUT', path, null)
+    return this._makeRequest('PUT', path, null, options)
   }
 
   /**
@@ -3825,10 +3825,10 @@ class Client extends BaseClient {
    * @param {PurchaseCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices
    */
-  async createPurchase (body) {
+  async createPurchase (body, options = {}) {
     let path = '/purchases'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 
   /**
@@ -3870,10 +3870,10 @@ class Client extends BaseClient {
    * @param {PurchaseCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns preview of the new invoices
    */
-  async previewPurchase (body) {
+  async previewPurchase (body, options = {}) {
     let path = '/purchases/preview'
     path = this._interpolatePath(path)
-    return this._makeRequest('POST', path, body)
+    return this._makeRequest('POST', path, body, options)
   }
 }
 

--- a/lib/recurly/api_errors.js
+++ b/lib/recurly/api_errors.js
@@ -9,73 +9,86 @@
 
 let ApiError = require('./ApiError')
 
-class BadRequestError extends ApiError { }
+class ResponseError extends ApiError { }
+class ServerError extends ResponseError { }
+class InternalServerError extends ServerError { }
+class BadGatewayError extends ServerError { }
+class ServiceUnavailableError extends ServerError { }
+class TimeoutError extends ServerError { }
+class RedirectionError extends ResponseError { }
+class NotModifiedError extends ResponseError { }
+class ClientError extends ApiError { }
+class BadRequestError extends ClientError { }
+class InvalidContentTypeError extends BadRequestError { }
+class UnauthorizedError extends ClientError { }
+class PaymentRequiredError extends ClientError { }
+class ForbiddenError extends ClientError { }
+class InvalidApiKeyError extends ForbiddenError { }
+class InvalidPermissionsError extends ForbiddenError { }
+class NotFoundError extends ClientError { }
+class NotAcceptableError extends ClientError { }
+class UnknownApiVersionError extends NotAcceptableError { }
+class UnavailableInApiVersionError extends NotAcceptableError { }
+class InvalidApiVersionError extends NotAcceptableError { }
+class PreconditionFailedError extends ClientError { }
+class UnprocessableEntityError extends ClientError { }
+class ValidationError extends UnprocessableEntityError { }
+class MissingFeatureError extends UnprocessableEntityError { }
+class TransactionError extends UnprocessableEntityError { }
+class SimultaneousRequestError extends UnprocessableEntityError { }
+class ImmutableSubscriptionError extends UnprocessableEntityError { }
+class InvalidTokenError extends UnprocessableEntityError { }
+class TooManyRequestsError extends ClientError { }
+class RateLimitedError extends TooManyRequestsError { }
 
-class InternalServerError extends ApiError { }
-
-class ImmutableSubscriptionError extends ApiError { }
-
-class InvalidApiKeyError extends ApiError { }
-
-class InvalidApiVersionError extends ApiError { }
-
-class InvalidContentTypeError extends ApiError { }
-
-class InvalidPermissionsError extends ApiError { }
-
-class InvalidTokenError extends ApiError { }
-
-class NotFoundError extends ApiError { }
-
-class SimultaneousRequestError extends ApiError { }
-
-class TransactionError extends ApiError { }
-
-class UnauthorizedError extends ApiError { }
-
-class UnavailableInApiVersionError extends ApiError { }
-
-class UnknownApiVersionError extends ApiError { }
-
-class ValidationError extends ApiError { }
-
-class MissingFeatureError extends ApiError { }
-
-class RateLimitedError extends ApiError { }
+const ERROR_MAP = {
+  500: InternalServerError,
+  502: BadGatewayError,
+  503: ServiceUnavailableError,
+  504: TimeoutError,
+  304: NotModifiedError,
+  400: BadRequestError,
+  401: UnauthorizedError,
+  402: PaymentRequiredError,
+  403: ForbiddenError,
+  404: NotFoundError,
+  406: NotAcceptableError,
+  412: PreconditionFailedError,
+  422: UnprocessableEntityError,
+  429: TooManyRequestsError
+}
 
 module.exports = {
-
-  BadRequestError: BadRequestError,
-
+  ERROR_MAP: ERROR_MAP,
+  ResponseError: ResponseError,
+  ServerError: ServerError,
   InternalServerError: InternalServerError,
-
-  ImmutableSubscriptionError: ImmutableSubscriptionError,
-
-  InvalidApiKeyError: InvalidApiKeyError,
-
-  InvalidApiVersionError: InvalidApiVersionError,
-
+  BadGatewayError: BadGatewayError,
+  ServiceUnavailableError: ServiceUnavailableError,
+  TimeoutError: TimeoutError,
+  RedirectionError: RedirectionError,
+  NotModifiedError: NotModifiedError,
+  ClientError: ClientError,
+  BadRequestError: BadRequestError,
   InvalidContentTypeError: InvalidContentTypeError,
-
-  InvalidPermissionsError: InvalidPermissionsError,
-
-  InvalidTokenError: InvalidTokenError,
-
-  NotFoundError: NotFoundError,
-
-  SimultaneousRequestError: SimultaneousRequestError,
-
-  TransactionError: TransactionError,
-
   UnauthorizedError: UnauthorizedError,
-
-  UnavailableInApiVersionError: UnavailableInApiVersionError,
-
+  PaymentRequiredError: PaymentRequiredError,
+  ForbiddenError: ForbiddenError,
+  InvalidApiKeyError: InvalidApiKeyError,
+  InvalidPermissionsError: InvalidPermissionsError,
+  NotFoundError: NotFoundError,
+  NotAcceptableError: NotAcceptableError,
   UnknownApiVersionError: UnknownApiVersionError,
-
+  UnavailableInApiVersionError: UnavailableInApiVersionError,
+  InvalidApiVersionError: InvalidApiVersionError,
+  PreconditionFailedError: PreconditionFailedError,
+  UnprocessableEntityError: UnprocessableEntityError,
   ValidationError: ValidationError,
-
   MissingFeatureError: MissingFeatureError,
-
+  TransactionError: TransactionError,
+  SimultaneousRequestError: SimultaneousRequestError,
+  ImmutableSubscriptionError: ImmutableSubscriptionError,
+  InvalidTokenError: InvalidTokenError,
+  TooManyRequestsError: TooManyRequestsError,
   RateLimitedError: RateLimitedError
 }

--- a/lib/recurly/network_errors.js
+++ b/lib/recurly/network_errors.js
@@ -3,6 +3,8 @@
 
 let ApiError = require('./ApiError')
 
+// There is a generated ServiceUnavailableError in api_errors.js
+// To prevent breaking changes, this one is being left in place.
 class ServiceUnavailableError extends ApiError { }
 
 class TimeoutError extends ApiError { }


### PR DESCRIPTION
Non-breaking update to error classes to give them a hierarchical structure. This will facilitate differentiating between a `ClientError` and a `ServerError` for example.

New error classes have also been added to be parent classes for some existing errors (e.g. `ForbiddenError` is a new class and both `InvalidApiKeyError` and `InvalidPermissionsError` extend it)

