### PR TITLE
Add request types to TS definitions

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -8,38 +8,38 @@ export interface Site {
   /**
    * Site ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
-  subdomain: string | null;
+  object?: string | null;
+  subdomain?: string | null;
   /**
    * This value is used to configure RecurlyJS to submit tokenized billing information.
    */
-  publicApiKey: string | null;
+  publicApiKey?: string | null;
   /**
    * Mode
    */
-  mode: string | null;
-  address: Address | null;
-  settings: Settings | null;
+  mode?: string | null;
+  address?: Address | null;
+  settings?: Settings | null;
   /**
    * A list of features enabled for the site.
    */
-  features: string[] | null;
+  features?: string[] | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -47,39 +47,39 @@ export interface Address {
   /**
    * First name
    */
-  firstName: string | null;
+  firstName?: string | null;
   /**
    * Last name
    */
-  lastName: string | null;
+  lastName?: string | null;
   /**
    * Phone number
    */
-  phone: string | null;
+  phone?: string | null;
   /**
    * Street 1
    */
-  street1: string | null;
+  street1?: string | null;
   /**
    * Street 2
    */
-  street2: string | null;
+  street2?: string | null;
   /**
    * City
    */
-  city: string | null;
+  city?: string | null;
   /**
    * State or province.
    */
-  region: string | null;
+  region?: string | null;
   /**
    * Zip or postal code.
    */
-  postalCode: string | null;
+  postalCode?: string | null;
   /**
    * Country, 2-letter ISO code.
    */
-  country: string | null;
+  country?: string | null;
 
 }
 
@@ -87,12 +87,12 @@ export interface Settings {
   /**
    * - full:      Full Address (Street, City, State, Postal Code and Country) - streetzip: Street and Postal Code only - zip:       Postal Code only - none:      No Address 
    */
-  billingAddressRequirement: string | null;
-  acceptedCurrencies: string[] | null;
+  billingAddressRequirement?: string | null;
+  acceptedCurrencies?: string[] | null;
   /**
    * The default 3-letter ISO 4217 currency code.
    */
-  defaultCurrency: string | null;
+  defaultCurrency?: string | null;
 
 }
 
@@ -100,121 +100,121 @@ export interface Error {
   /**
    * Type
    */
-  type: string | null;
+  type?: string | null;
   /**
    * Message
    */
-  message: string | null;
+  message?: string | null;
   /**
    * Parameter specific errors
    */
-  params: object[] | null;
+  params?: object[] | null;
 
 }
 
 export interface Account {
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Accounts can be either active or inactive.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: `https://{subdomain}.recurly.com/account/{hosted_login_token}`.
    */
-  hostedLoginToken: string | null;
+  hostedLoginToken?: string | null;
   /**
    * The shipping addresses on the account.
    */
-  shippingAddresses: ShippingAddress[] | null;
+  shippingAddresses?: ShippingAddress[] | null;
   /**
    * Indicates if the account has a subscription that is either active, canceled, future, or paused.
    */
-  hasLiveSubscription: boolean | null;
+  hasLiveSubscription?: boolean | null;
   /**
    * Indicates if the account has an active subscription.
    */
-  hasActiveSubscription: boolean | null;
+  hasActiveSubscription?: boolean | null;
   /**
    * Indicates if the account has a future subscription.
    */
-  hasFutureSubscription: boolean | null;
+  hasFutureSubscription?: boolean | null;
   /**
    * Indicates if the account has a canceled subscription.
    */
-  hasCanceledSubscription: boolean | null;
+  hasCanceledSubscription?: boolean | null;
   /**
    * Indicates if the account has a paused subscription.
    */
-  hasPausedSubscription: boolean | null;
+  hasPausedSubscription?: boolean | null;
   /**
    * Indicates if the account has a past due invoice.
    */
-  hasPastDueInvoice: boolean | null;
+  hasPastDueInvoice?: boolean | null;
   /**
    * When the account was created.
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * When the account was last changed.
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * If present, when the account was last marked inactive.
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
   /**
    * The unique identifier of the account. This cannot be changed once the account is created.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * A secondary value for the account.
    */
-  username: string | null;
+  username?: string | null;
   /**
    * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
    */
-  email: string | null;
+  email?: string | null;
   /**
    * Used to determine the language and locale of emails sent on behalf of the merchant to the customer.
    */
-  preferredLocale: string | null;
+  preferredLocale?: string | null;
   /**
    * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
    */
-  ccEmails: string | null;
-  firstName: string | null;
-  lastName: string | null;
-  company: string | null;
+  ccEmails?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
   /**
    * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
    */
-  vatNumber: string | null;
+  vatNumber?: string | null;
   /**
    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
    */
-  taxExempt: boolean | null;
+  taxExempt?: boolean | null;
   /**
    * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
    */
-  exemptionCertificate: string | null;
+  exemptionCertificate?: string | null;
   /**
    * The UUID of the parent account associated with this account.
    */
-  parentAccountId: string | null;
+  parentAccountId?: string | null;
   /**
    * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
    */
-  billTo: string | null;
-  address: Address | null;
-  billingInfo: BillingInfo | null;
+  billTo?: string | null;
+  address?: Address | null;
+  billingInfo?: BillingInfo | null;
   /**
    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
    */
-  customFields: CustomField[] | null;
+  customFields?: CustomField[] | null;
 
 }
 
@@ -222,135 +222,135 @@ export interface ShippingAddress {
   /**
    * Shipping Address ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Account ID
    */
-  accountId: string | null;
-  nickname: string | null;
-  firstName: string | null;
-  lastName: string | null;
-  company: string | null;
-  email: string | null;
-  vatNumber: string | null;
-  phone: string | null;
-  street1: string | null;
-  street2: string | null;
-  city: string | null;
+  accountId?: string | null;
+  nickname?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  email?: string | null;
+  vatNumber?: string | null;
+  phone?: string | null;
+  street1?: string | null;
+  street2?: string | null;
+  city?: string | null;
   /**
    * State or province.
    */
-  region: string | null;
+  region?: string | null;
   /**
    * Zip or postal code.
    */
-  postalCode: string | null;
+  postalCode?: string | null;
   /**
    * Country, 2-letter ISO code.
    */
-  country: string | null;
+  country?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
 
 }
 
 export interface BillingInfo {
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
-  accountId: string | null;
-  firstName: string | null;
-  lastName: string | null;
-  company: string | null;
-  address: Address | null;
+  object?: string | null;
+  accountId?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  address?: Address | null;
   /**
    * Customer's VAT number (to avoid having the VAT applied). This is only used for automatically collected invoices.
    */
-  vatNumber: string | null;
-  valid: boolean | null;
-  paymentMethod: PaymentMethod | null;
+  vatNumber?: string | null;
+  valid?: boolean | null;
+  paymentMethod?: PaymentMethod | null;
   /**
    * Most recent fraud result.
    */
-  fraud: FraudInfo | null;
+  fraud?: FraudInfo | null;
   /**
    * When the billing information was created.
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * When the billing information was last changed.
    */
-  updatedAt: Date | null;
-  updatedBy: BillingInfoUpdatedBy | null;
+  updatedAt?: Date | null;
+  updatedBy?: BillingInfoUpdatedBy | null;
 
 }
 
 export interface PaymentMethod {
-  object: string | null;
+  object?: string | null;
   /**
    * Visa, MasterCard, American Express, Discover, JCB, etc.
    */
-  cardType: string | null;
+  cardType?: string | null;
   /**
    * Credit card number's first six digits.
    */
-  firstSix: string | null;
+  firstSix?: string | null;
   /**
    * Credit card number's last four digits. Will refer to bank account if payment method is ACH.
    */
-  lastFour: string | null;
+  lastFour?: string | null;
   /**
    * The IBAN bank account's last two digits.
    */
-  lastTwo: string | null;
+  lastTwo?: string | null;
   /**
    * Expiration month.
    */
-  expMonth: number | null;
+  expMonth?: number | null;
   /**
    * Expiration year.
    */
-  expYear: number | null;
+  expYear?: number | null;
   /**
    * A token used in place of a credit card in order to perform transactions.
    */
-  gatewayToken: string | null;
+  gatewayToken?: string | null;
   /**
    * An identifier for a specific payment gateway.
    */
-  gatewayCode: string | null;
+  gatewayCode?: string | null;
   /**
    * Billing Agreement identifier. Only present for Amazon or Paypal payment methods.
    */
-  billingAgreementId: string | null;
+  billingAgreementId?: string | null;
   /**
    * The name associated with the bank account.
    */
-  nameOnAccount: string | null;
+  nameOnAccount?: string | null;
   /**
    * The bank account type. Only present for ACH payment methods.
    */
-  accountType: string | null;
+  accountType?: string | null;
   /**
    * The bank account's routing number. Only present for ACH payment methods.
    */
-  routingNumber: string | null;
+  routingNumber?: string | null;
   /**
    * The bank name of this routing number.
    */
-  routingNumberBank: string | null;
+  routingNumberBank?: string | null;
 
 }
 
@@ -358,15 +358,15 @@ export interface FraudInfo {
   /**
    * Kount score
    */
-  score: number | null;
+  score?: number | null;
   /**
    * Kount decision
    */
-  decision: string | null;
+  decision?: string | null;
   /**
    * Kount rules
    */
-  riskRulesTriggered: object | null;
+  riskRulesTriggered?: object | null;
 
 }
 
@@ -374,11 +374,11 @@ export interface BillingInfoUpdatedBy {
   /**
    * Customer's IP address when updating their billing information.
    */
-  ip: string | null;
+  ip?: string | null;
   /**
    * Country of IP address, if known by Recurly.
    */
-  country: string | null;
+  country?: string | null;
 
 }
 
@@ -386,11 +386,11 @@ export interface CustomField {
   /**
    * Fields must be created in the UI before values can be assigned to them.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
    */
-  value: string | null;
+  value?: string | null;
 
 }
 
@@ -398,19 +398,19 @@ export interface ErrorMayHaveTransaction {
   /**
    * Type
    */
-  type: string | null;
+  type?: string | null;
   /**
    * Message
    */
-  message: string | null;
+  message?: string | null;
   /**
    * Parameter specific errors
    */
-  params: object[] | null;
+  params?: object[] | null;
   /**
    * This is only included on errors with `type=transaction`.
    */
-  transactionError: TransactionError | null;
+  transactionError?: TransactionError | null;
 
 }
 
@@ -418,31 +418,31 @@ export interface TransactionError {
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Transaction ID
    */
-  transactionId: string | null;
+  transactionId?: string | null;
   /**
    * Category
    */
-  category: string | null;
+  category?: string | null;
   /**
    * Code
    */
-  code: string | null;
+  code?: string | null;
   /**
    * Customer message
    */
-  message: string | null;
+  message?: string | null;
   /**
    * Merchant message
    */
-  merchantAdvice: string | null;
+  merchantAdvice?: string | null;
   /**
    * Returned when 3-D Secure authentication is required for a transaction. Pass this value to Recurly.js so it can continue the challenge flow.
    */
-  threeDSecureActionTokenId: string | null;
+  threeDSecureActionTokenId?: string | null;
 
 }
 
@@ -450,36 +450,36 @@ export interface AccountAcquisition {
   /**
    * Account balance
    */
-  cost: AccountAcquisitionCost | null;
+  cost?: AccountAcquisitionCost | null;
   /**
    * The channel through which the account was acquired.
    */
-  channel: string | null;
+  channel?: string | null;
   /**
    * An arbitrary subchannel string representing a distinction/subcategory within a broader channel.
    */
-  subchannel: string | null;
+  subchannel?: string | null;
   /**
    * An arbitrary identifier for the marketing campaign that led to the acquisition of this account.
    */
-  campaign: string | null;
-  id: string | null;
+  campaign?: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
+  account?: AccountMini | null;
   /**
    * When the account acquisition data was created.
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * When the account acquisition data was last changed.
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
 
 }
 
@@ -487,33 +487,33 @@ export interface AccountAcquisitionCost {
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * The amount of the corresponding currency used to acquire the account.
    */
-  amount: number | null;
+  amount?: number | null;
 
 }
 
 export interface AccountMini {
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The unique identifier of the account.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The email address used for communicating with this customer.
    */
-  email: string | null;
-  firstName: string | null;
-  lastName: string | null;
-  company: string | null;
-  parentAccountId: string | null;
-  billTo: string | null;
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  parentAccountId?: string | null;
+  billTo?: string | null;
 
 }
 
@@ -521,13 +521,13 @@ export interface AccountBalance {
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
-  pastDue: boolean | null;
-  balances: AccountBalanceAmount[] | null;
+  account?: AccountMini | null;
+  pastDue?: boolean | null;
+  balances?: AccountBalanceAmount[] | null;
 
 }
 
@@ -535,11 +535,11 @@ export interface AccountBalanceAmount {
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Total amount the account is past due.
    */
-  amount: number | null;
+  amount?: number | null;
 
 }
 
@@ -547,40 +547,40 @@ export interface CouponRedemption {
   /**
    * Coupon Redemption ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Will always be `coupon`.
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The Account on which the coupon was applied.
    */
-  account: AccountMini | null;
-  coupon: Coupon | null;
+  account?: AccountMini | null;
+  coupon?: Coupon | null;
   /**
    * Coupon Redemption state
    */
-  state: string | null;
+  state?: string | null;
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * The amount that was discounted upon the application of the coupon, formatted with the currency.
    */
-  discounted: number | null;
+  discounted?: number | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * The date and time the redemption was removed from the account (un-redeemed).
    */
-  removedAt: Date | null;
+  removedAt?: Date | null;
 
 }
 
@@ -588,115 +588,115 @@ export interface Coupon {
   /**
    * Coupon ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The code the customer enters to redeem the coupon.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The internal name for the coupon.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Indicates if the coupon is redeemable, and if it is not, why.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
    */
-  maxRedemptions: number | null;
+  maxRedemptions?: number | null;
   /**
    * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
    */
-  maxRedemptionsPerAccount: number | null;
+  maxRedemptionsPerAccount?: number | null;
   /**
    * When this number reaches `max_redemptions` the coupon will no longer be redeemable.
    */
-  uniqueCouponCodesCount: number | null;
+  uniqueCouponCodesCount?: number | null;
   /**
    * On a bulk coupon, the template from which unique coupon codes are generated.
    */
-  uniqueCodeTemplate: string | null;
+  uniqueCodeTemplate?: string | null;
   /**
    * - "single_use" coupons applies to the first invoice only. - "temporal" coupons will apply to invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes. 
    */
-  duration: string | null;
+  duration?: string | null;
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
    */
-  temporalAmount: number | null;
+  temporalAmount?: number | null;
   /**
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
    */
-  temporalUnit: string | null;
+  temporalUnit?: string | null;
   /**
    * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine the duration of time the coupon is for.
    */
-  freeTrialUnit: string | null;
+  freeTrialUnit?: string | null;
   /**
    * Sets the duration of time the `free_trial_unit` is for.
    */
-  freeTrialAmount: number | null;
+  freeTrialAmount?: number | null;
   /**
    * The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans.
    */
-  appliesToAllPlans: boolean | null;
+  appliesToAllPlans?: boolean | null;
   /**
    * The coupon is valid for one-time, non-plan charges if true.
    */
-  appliesToNonPlanCharges: boolean | null;
+  appliesToNonPlanCharges?: boolean | null;
   /**
    * TODO
    */
-  plansNames: string[] | null;
+  plansNames?: string[] | null;
   /**
    * A list of plans for which this coupon applies. This will be `null` if `applies_to_all_plans=true`.
    */
-  plans: PlanMini[] | null;
+  plans?: PlanMini[] | null;
   /**
    * Whether the discount is for all eligible charges on the account, or only a specific subscription.
    */
-  redemptionResource: string | null;
+  redemptionResource?: string | null;
   /**
    * Details of the discount a coupon applies. Will contain a `type` property and one of the following properties: `percent`, `fixed`, `trial`. 
    */
-  discount: CouponDiscount | null;
+  discount?: CouponDiscount | null;
   /**
    * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  couponType: string | null;
+  couponType?: string | null;
   /**
    * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
    */
-  hostedPageDescription: string | null;
+  hostedPageDescription?: string | null;
   /**
    * Description of the coupon on the invoice.
    */
-  invoiceDescription: string | null;
+  invoiceDescription?: string | null;
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
    */
-  redeemBy: Date | null;
+  redeemBy?: Date | null;
   /**
    * The date and time the unique coupon code was redeemed. This is only present for bulk coupons.
    */
-  redeemedAt: Date | null;
+  redeemedAt?: Date | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * The date and time the coupon was expired early or reached its `max_redemptions`.
    */
-  expiredAt: Date | null;
+  expiredAt?: Date | null;
 
 }
 
@@ -704,36 +704,36 @@ export interface PlanMini {
   /**
    * Plan ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
    */
-  name: string | null;
+  name?: string | null;
 
 }
 
 export interface CouponDiscount {
-  type: string | null;
+  type?: string | null;
   /**
    * This is only present when `type=percent`.
    */
-  percent: number | null;
+  percent?: number | null;
   /**
    * This is only present when `type=fixed`.
    */
-  currencies: CouponDiscountPricing[] | null;
+  currencies?: CouponDiscountPricing[] | null;
   /**
    * This is only present when `type=free_trial`.
    */
-  trial: CouponDiscountTrial | null;
+  trial?: CouponDiscountTrial | null;
 
 }
 
@@ -741,11 +741,11 @@ export interface CouponDiscountPricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Value of the fixed discount that this coupon applies.
    */
-  amount: number | null;
+  amount?: number | null;
 
 }
 
@@ -753,11 +753,11 @@ export interface CouponDiscountTrial {
   /**
    * Temporal unit of the free trial
    */
-  unit: string | null;
+  unit?: string | null;
   /**
    * Trial length measured in the units specified by the sibling `unit` property
    */
-  length: number | null;
+  length?: number | null;
 
 }
 
@@ -765,56 +765,56 @@ export interface CreditPayment {
   /**
    * Credit Payment ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
    */
-  uuid: string | null;
+  uuid?: string | null;
   /**
    * The action for which the credit was created.
    */
-  action: string | null;
+  action?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
+  account?: AccountMini | null;
   /**
    * Invoice mini details
    */
-  appliedToInvoice: InvoiceMini | null;
+  appliedToInvoice?: InvoiceMini | null;
   /**
    * Invoice mini details
    */
-  originalInvoice: InvoiceMini | null;
+  originalInvoice?: InvoiceMini | null;
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Total credit payment amount applied to the charge invoice.
    */
-  amount: number | null;
+  amount?: number | null;
   /**
    * For credit payments with action `refund`, this is the credit payment that was refunded.
    */
-  originalCreditPaymentId: string | null;
-  refundTransaction: Transaction | null;
+  originalCreditPaymentId?: string | null;
+  refundTransaction?: Transaction | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Voided at
    */
-  voidedAt: Date | null;
+  voidedAt?: Date | null;
 
 }
 
@@ -822,23 +822,23 @@ export interface InvoiceMini {
   /**
    * Invoice ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Invoice number
    */
-  number: string | null;
+  number?: string | null;
   /**
    * Invoice type
    */
-  type: string | null;
+  type?: string | null;
   /**
    * Invoice state
    */
-  state: string | null;
+  state?: string | null;
 
 }
 
@@ -846,153 +846,153 @@ export interface Transaction {
   /**
    * Transaction ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
    */
-  uuid: string | null;
+  uuid?: string | null;
   /**
    * If this transaction is a refund (`type=refund`), this will be the ID of the original transaction on the invoice being refunded.
    */
-  originalTransactionId: string | null;
+  originalTransactionId?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
+  account?: AccountMini | null;
   /**
    * Invoice mini details
    */
-  invoice: InvoiceMini | null;
+  invoice?: InvoiceMini | null;
   /**
    * Invoice mini details
    */
-  voidedByInvoice: InvoiceMini | null;
+  voidedByInvoice?: InvoiceMini | null;
   /**
    * If the transaction is charging or refunding for one or more subscriptions, these are their IDs.
    */
-  subscriptionIds: string[] | null;
+  subscriptionIds?: string[] | null;
   /**
    * - `authorization` – verifies billing information and places a hold on money in the customer's account. - `capture` – captures funds held by an authorization and completes a purchase. - `purchase` – combines the authorization and capture in one transaction. - `refund` – returns all or a portion of the money collected in a previous transaction to the customer. - `verify` – a $0 or $1 transaction used to verify billing information which is immediately voided. 
    */
-  type: string | null;
+  type?: string | null;
   /**
    * Describes how the transaction was triggered.
    */
-  origin: string | null;
+  origin?: string | null;
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Total transaction amount sent to the payment gateway.
    */
-  amount: number | null;
+  amount?: number | null;
   /**
    * The current transaction status. Note that the status may change, e.g. a `pending` transaction may become `declined` or `success` may later become `void`.
    */
-  status: string | null;
+  status?: string | null;
   /**
    * Did this transaction complete successfully?
    */
-  success: boolean | null;
+  success?: boolean | null;
   /**
    * Indicates if part or all of this transaction was refunded.
    */
-  refunded: boolean | null;
-  billingAddress: Address | null;
+  refunded?: boolean | null;
+  billingAddress?: Address | null;
   /**
    * The method by which the payment was collected.
    */
-  collectionMethod: string | null;
-  paymentMethod: PaymentMethod | null;
+  collectionMethod?: string | null;
+  paymentMethod?: PaymentMethod | null;
   /**
    * IP address provided when the billing information was collected:  - When the customer enters billing information into the Recurly.js or Hosted Payment Pages, Recurly records the IP address. - When the merchant enters billing information using the API, the merchant may provide an IP address. - When the merchant enters billing information using the UI, no IP address is recorded. 
    */
-  ipAddressV4: string | null;
+  ipAddressV4?: string | null;
   /**
    * IP address's country
    */
-  ipAddressCountry: string | null;
+  ipAddressCountry?: string | null;
   /**
    * Status code
    */
-  statusCode: string | null;
+  statusCode?: string | null;
   /**
    * For declined (`success=false`) transactions, the message displayed to the merchant.
    */
-  statusMessage: string | null;
+  statusMessage?: string | null;
   /**
    * For declined (`success=false`) transactions, the message displayed to the customer.
    */
-  customerMessage: string | null;
+  customerMessage?: string | null;
   /**
    * Language code for the message
    */
-  customerMessageLocale: string | null;
-  paymentGateway: TransactionPaymentGateway | null;
+  customerMessageLocale?: string | null;
+  paymentGateway?: TransactionPaymentGateway | null;
   /**
    * Transaction message from the payment gateway.
    */
-  gatewayMessage: string | null;
+  gatewayMessage?: string | null;
   /**
    * Transaction reference number from the payment gateway.
    */
-  gatewayReference: string | null;
+  gatewayReference?: string | null;
   /**
    * Transaction approval code from the payment gateway.
    */
-  gatewayApprovalCode: string | null;
+  gatewayApprovalCode?: string | null;
   /**
    * For declined transactions (`success=false`), this field lists the gateway error code.
    */
-  gatewayResponseCode: string | null;
+  gatewayResponseCode?: string | null;
   /**
    * Time, in seconds, for gateway to process the transaction.
    */
-  gatewayResponseTime: number | null;
+  gatewayResponseTime?: number | null;
   /**
    * The values in this field will vary from gateway to gateway.
    */
-  gatewayResponseValues: object | null;
+  gatewayResponseValues?: object | null;
   /**
    * When processed, result from checking the CVV/CVC value on the transaction.
    */
-  cvvCheck: string | null;
+  cvvCheck?: string | null;
   /**
    * When processed, result from checking the overall AVS on the transaction.
    */
-  avsCheck: string | null;
+  avsCheck?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Voided at
    */
-  voidedAt: Date | null;
+  voidedAt?: Date | null;
   /**
    * Collected at, or if not collected yet, the time the transaction was created.
    */
-  collectedAt: Date | null;
+  collectedAt?: Date | null;
 
 }
 
 export interface TransactionPaymentGateway {
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
-  type: string | null;
-  name: string | null;
+  object?: string | null;
+  type?: string | null;
+  name?: string | null;
 
 }
 
@@ -1000,130 +1000,130 @@ export interface Invoice {
   /**
    * Invoice ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Invoices are either charge, credit, or legacy invoices.
    */
-  type: string | null;
+  type?: string | null;
   /**
    * The event that created the invoice.
    */
-  origin: string | null;
+  origin?: string | null;
   /**
    * Invoice state
    */
-  state: string | null;
+  state?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
+  account?: AccountMini | null;
   /**
    * If the invoice is charging or refunding for one or more subscriptions, these are their IDs.
    */
-  subscriptionIds: string[] | null;
+  subscriptionIds?: string[] | null;
   /**
    * On refund invoices, this value will exist and show the invoice ID of the purchase invoice the refund was created from.
    */
-  previousInvoiceId: string | null;
+  previousInvoiceId?: string | null;
   /**
    * If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
    */
-  number: string | null;
+  number?: string | null;
   /**
    * An automatic invoice means a corresponding transaction is run using the account's billing information at the same time the invoice is created. Manual invoices are created without a corresponding transaction. The merchant must enter a manual payment transaction or have the customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH bank payment.
    */
-  collectionMethod: string | null;
+  collectionMethod?: string | null;
   /**
    * For manual invoicing, this identifies the PO number associated with the subscription.
    */
-  poNumber: string | null;
+  poNumber?: string | null;
   /**
    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
    */
-  netTerms: number | null;
-  address: InvoiceAddress | null;
-  shippingAddress: ShippingAddress | null;
+  netTerms?: number | null;
+  address?: InvoiceAddress | null;
+  shippingAddress?: ShippingAddress | null;
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Total discounts applied to this invoice.
    */
-  discount: number | null;
+  discount?: number | null;
   /**
    * The summation of charges, discounts, and credits, before tax.
    */
-  subtotal: number | null;
+  subtotal?: number | null;
   /**
    * The total tax on this invoice.
    */
-  tax: number | null;
+  tax?: number | null;
   /**
    * The final total on this invoice. The summation of invoice charges, discounts, credits, and tax.
    */
-  total: number | null;
+  total?: number | null;
   /**
    * The refundable amount on a charge invoice. It will be null for all other invoices.
    */
-  refundableAmount: number | null;
+  refundableAmount?: number | null;
   /**
    * The total amount of successful payments transaction on this invoice.
    */
-  paid: number | null;
+  paid?: number | null;
   /**
    * The outstanding balance remaining on this invoice.
    */
-  balance: number | null;
+  balance?: number | null;
   /**
    * Tax info
    */
-  taxInfo: TaxInfo | null;
+  taxInfo?: TaxInfo | null;
   /**
    * VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
    */
-  vatNumber: string | null;
+  vatNumber?: string | null;
   /**
    * VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
    */
-  vatReverseChargeNotes: string | null;
+  vatReverseChargeNotes?: string | null;
   /**
    * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions.
    */
-  termsAndConditions: string | null;
+  termsAndConditions?: string | null;
   /**
    * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.
    */
-  customerNotes: string | null;
-  lineItems: LineItemList | null;
+  customerNotes?: string | null;
+  lineItems?: LineItemList | null;
   /**
    * Transactions
    */
-  transactions: Transaction[] | null;
+  transactions?: Transaction[] | null;
   /**
    * Credit payments
    */
-  creditPayments: CreditPayment[] | null;
+  creditPayments?: CreditPayment[] | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Date invoice is due. This is the date the net terms are reached.
    */
-  dueAt: Date | null;
+  dueAt?: Date | null;
   /**
    * Date invoice was marked paid or failed.
    */
-  closedAt: Date | null;
+  closedAt?: Date | null;
 
 }
 
@@ -1131,47 +1131,47 @@ export interface InvoiceAddress {
   /**
    * Name on account
    */
-  nameOnAccount: string | null;
+  nameOnAccount?: string | null;
   /**
    * Company
    */
-  company: string | null;
+  company?: string | null;
   /**
    * First name
    */
-  firstName: string | null;
+  firstName?: string | null;
   /**
    * Last name
    */
-  lastName: string | null;
+  lastName?: string | null;
   /**
    * Phone number
    */
-  phone: string | null;
+  phone?: string | null;
   /**
    * Street 1
    */
-  street1: string | null;
+  street1?: string | null;
   /**
    * Street 2
    */
-  street2: string | null;
+  street2?: string | null;
   /**
    * City
    */
-  city: string | null;
+  city?: string | null;
   /**
    * State or province.
    */
-  region: string | null;
+  region?: string | null;
   /**
    * Zip or postal code.
    */
-  postalCode: string | null;
+  postalCode?: string | null;
   /**
    * Country, 2-letter ISO code.
    */
-  country: string | null;
+  country?: string | null;
 
 }
 
@@ -1179,15 +1179,15 @@ export interface TaxInfo {
   /**
    * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
    */
-  type: string | null;
+  type?: string | null;
   /**
    * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.
    */
-  region: string | null;
+  region?: string | null;
   /**
    * Rate
    */
-  rate: number | null;
+  rate?: number | null;
 
 }
 
@@ -1195,16 +1195,16 @@ export interface LineItemList {
   /**
    * Will always be List.
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Indicates there are more results on subsequent pages.
    */
-  hasMore: boolean | null;
+  hasMore?: boolean | null;
   /**
    * Path to subsequent page of results.
    */
-  next: string | null;
-  data: LineItem[] | null;
+  next?: string | null;
+  data?: LineItem[] | null;
 
 }
 
@@ -1212,180 +1212,180 @@ export interface LineItem {
   /**
    * Line item ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
    */
-  uuid: string | null;
+  uuid?: string | null;
   /**
    * Charges are positive line items that debit the account. Credits are negative line items that credit the account.
    */
-  type: string | null;
+  type?: string | null;
   /**
    * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
    */
-  itemCode: string | null;
+  itemCode?: string | null;
   /**
    * System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
    */
-  itemId: string | null;
+  itemId?: string | null;
   /**
    * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
    */
-  externalSku: string | null;
+  externalSku?: string | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Pending line items are charges or credits on an account that have not been applied to an invoice yet. Invoiced line items will always have an `invoice_id` value.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * Category to describe the role of a line item on a legacy invoice: - "charges" refers to charges being billed for on this invoice. - "credits" refers to refund or proration credits. This portion of the invoice can be considered a credit memo. - "applied_credits" refers to previous credits applied to this invoice. See their original_line_item_id to determine where the credit first originated. - "carryforwards" can be ignored. They exist to consume any remaining credit balance. A new credit with the same amount will be created and placed back on the account. 
    */
-  legacyCategory: string | null;
+  legacyCategory?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
+  account?: AccountMini | null;
   /**
    * If the line item is a charge or credit for a subscription, this is its ID.
    */
-  subscriptionId: string | null;
+  subscriptionId?: string | null;
   /**
    * If the line item is a charge or credit for a plan or add-on, this is the plan's ID.
    */
-  planId: string | null;
+  planId?: string | null;
   /**
    * If the line item is a charge or credit for a plan or add-on, this is the plan's code.
    */
-  planCode: string | null;
+  planCode?: string | null;
   /**
    * If the line item is a charge or credit for an add-on this is its ID.
    */
-  addOnId: string | null;
+  addOnId?: string | null;
   /**
    * If the line item is a charge or credit for an add-on, this is its code.
    */
-  addOnCode: string | null;
+  addOnCode?: string | null;
   /**
    * Once the line item has been invoiced this will be the invoice's ID.
    */
-  invoiceId: string | null;
+  invoiceId?: string | null;
   /**
    * Once the line item has been invoiced this will be the invoice's number. If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
    */
-  invoiceNumber: string | null;
+  invoiceNumber?: string | null;
   /**
    * Will only have a value if the line item is a credit created from a previous credit, or if the credit was created from a charge refund.
    */
-  previousLineItemId: string | null;
+  previousLineItemId?: string | null;
   /**
    * The invoice where the credit originated. Will only have a value if the line item is a credit created from a previous credit, or if the credit was created from a charge refund.
    */
-  originalLineItemInvoiceId: string | null;
+  originalLineItemInvoiceId?: string | null;
   /**
    * A credit created from an original charge will have the value of the charge's origin.
    */
-  origin: string | null;
+  origin?: string | null;
   /**
    * Internal accounting code to help you reconcile your revenue to the correct ledger. Line items created as part of a subscription invoice will use the plan or add-on's accounting code, otherwise the value will only be present if you define an accounting code when creating the line item.
    */
-  accountingCode: string | null;
+  accountingCode?: string | null;
   /**
    * For plan-related line items this will be the plan's code, for add-on related line items it will be the add-on's code. For item-related line items it will be the item's `external_sku`.
    */
-  productCode: string | null;
+  productCode?: string | null;
   /**
    * The reason the credit was given when line item is `type=credit`.
    */
-  creditReasonCode: string | null;
+  creditReasonCode?: string | null;
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * `(quantity * unit_amount) - (discount + tax)`
    */
-  amount: number | null;
+  amount?: number | null;
   /**
    * Description that appears on the invoice. For subscription related items this will be filled in automatically.
    */
-  description: string | null;
+  description?: string | null;
   /**
    * This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
    */
-  quantity: number | null;
+  quantity?: number | null;
   /**
    * Positive amount for a charge, negative amount for a credit.
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
   /**
    * `quantity * unit_amount`
    */
-  subtotal: number | null;
+  subtotal?: number | null;
   /**
    * The discount applied to the line item.
    */
-  discount: number | null;
+  discount?: number | null;
   /**
    * The tax amount for the line item.
    */
-  tax: number | null;
+  tax?: number | null;
   /**
    * `true` if the line item is taxable, `false` if it is not.
    */
-  taxable: boolean | null;
+  taxable?: boolean | null;
   /**
    * `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
    */
-  taxExempt: boolean | null;
+  taxExempt?: boolean | null;
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
    */
-  taxCode: string | null;
+  taxCode?: string | null;
   /**
    * Tax info
    */
-  taxInfo: TaxInfo | null;
+  taxInfo?: TaxInfo | null;
   /**
    * When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
    */
-  prorationRate: number | null;
+  prorationRate?: number | null;
   /**
    * Refund?
    */
-  refund: boolean | null;
+  refund?: boolean | null;
   /**
    * For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
    */
-  refundedQuantity: number | null;
+  refundedQuantity?: number | null;
   /**
    * The amount of credit from this line item that was applied to the invoice.
    */
-  creditApplied: number | null;
-  shippingAddress: ShippingAddress | null;
+  creditApplied?: number | null;
+  shippingAddress?: ShippingAddress | null;
   /**
    * If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date.
    */
-  startDate: Date | null;
+  startDate?: Date | null;
   /**
    * If this date is provided, it indicates the end of a time range.
    */
-  endDate: Date | null;
+  endDate?: Date | null;
   /**
    * When the line item was created.
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * When the line item was last changed.
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
 
 }
 
@@ -1393,40 +1393,40 @@ export interface InvoiceCollection {
   /**
    * Object type
    */
-  object: string | null;
-  chargeInvoice: Invoice | null;
+  object?: string | null;
+  chargeInvoice?: Invoice | null;
   /**
    * Credit invoices
    */
-  creditInvoices: Invoice[] | null;
+  creditInvoices?: Invoice[] | null;
 
 }
 
 export interface AccountNote {
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
-  accountId: string | null;
-  user: User | null;
-  message: string | null;
-  createdAt: Date | null;
+  object?: string | null;
+  accountId?: string | null;
+  user?: User | null;
+  message?: string | null;
+  createdAt?: Date | null;
 
 }
 
 export interface User {
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
-  email: string | null;
-  firstName: string | null;
-  lastName: string | null;
-  timeZone: string | null;
-  createdAt: Date | null;
-  deletedAt: Date | null;
+  object?: string | null;
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  timeZone?: string | null;
+  createdAt?: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -1434,167 +1434,167 @@ export interface Subscription {
   /**
    * Subscription ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The UUID is useful for matching data with the CSV exports and building URLs into Recurly's UI.
    */
-  uuid: string | null;
+  uuid?: string | null;
   /**
    * Account mini details
    */
-  account: AccountMini | null;
+  account?: AccountMini | null;
   /**
    * Just the important parts.
    */
-  plan: PlanMini | null;
+  plan?: PlanMini | null;
   /**
    * State
    */
-  state: string | null;
+  state?: string | null;
   /**
    * Subscription shipping details
    */
-  shipping: SubscriptionShipping | null;
+  shipping?: SubscriptionShipping | null;
   /**
    * Coupon redemptions
    */
-  couponRedemptions: CouponRedemptionMini[] | null;
+  couponRedemptions?: CouponRedemptionMini[] | null;
   /**
    * Subscription Change
    */
-  pendingChange: SubscriptionChange | null;
+  pendingChange?: SubscriptionChange | null;
   /**
    * Current billing period started at
    */
-  currentPeriodStartedAt: Date | null;
+  currentPeriodStartedAt?: Date | null;
   /**
    * Current billing period ends at
    */
-  currentPeriodEndsAt: Date | null;
+  currentPeriodEndsAt?: Date | null;
   /**
    * The start date of the term when the first billing period starts. The subscription term is the length of time that a customer will be committed to a subscription. A term can span multiple billing periods.
    */
-  currentTermStartedAt: Date | null;
+  currentTermStartedAt?: Date | null;
   /**
    * When the term ends. This is calculated by a plan's interval and `total_billing_cycles` in a term. Subscription changes with a `timeframe=renewal` will be applied on this date.
    */
-  currentTermEndsAt: Date | null;
+  currentTermEndsAt?: Date | null;
   /**
    * Trial period started at
    */
-  trialStartedAt: Date | null;
+  trialStartedAt?: Date | null;
   /**
    * Trial period ends at
    */
-  trialEndsAt: Date | null;
+  trialEndsAt?: Date | null;
   /**
    * The remaining billing cycles in the current term.
    */
-  remainingBillingCycles: number | null;
+  remainingBillingCycles?: number | null;
   /**
    * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
    */
-  totalBillingCycles: number | null;
+  totalBillingCycles?: number | null;
   /**
    * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
    */
-  renewalBillingCycles: number | null;
+  renewalBillingCycles?: number | null;
   /**
    * Whether the subscription renews at the end of its term.
    */
-  autoRenew: boolean | null;
+  autoRenew?: boolean | null;
   /**
    * Null unless subscription is paused or will pause at the end of the current billing period.
    */
-  pausedAt: Date | null;
+  pausedAt?: Date | null;
   /**
    * Null unless subscription is paused or will pause at the end of the current billing period.
    */
-  remainingPauseCycles: number | null;
+  remainingPauseCycles?: number | null;
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Subscription unit price
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
   /**
    * Subscription quantity
    */
-  quantity: number | null;
+  quantity?: number | null;
   /**
    * Add-ons
    */
-  addOns: SubscriptionAddOn[] | null;
+  addOns?: SubscriptionAddOn[] | null;
   /**
    * Total price of add-ons
    */
-  addOnsTotal: number | null;
+  addOnsTotal?: number | null;
   /**
    * Estimated total, before tax.
    */
-  subtotal: number | null;
+  subtotal?: number | null;
   /**
    * Collection method
    */
-  collectionMethod: string | null;
+  collectionMethod?: string | null;
   /**
    * For manual invoicing, this identifies the PO number associated with the subscription.
    */
-  poNumber: string | null;
+  poNumber?: string | null;
   /**
    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
    */
-  netTerms: number | null;
+  netTerms?: number | null;
   /**
    * Terms and conditions
    */
-  termsAndConditions: string | null;
+  termsAndConditions?: string | null;
   /**
    * Customer notes
    */
-  customerNotes: string | null;
+  customerNotes?: string | null;
   /**
    * Expiration reason
    */
-  expirationReason: string | null;
+  expirationReason?: string | null;
   /**
    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
    */
-  customFields: CustomField[] | null;
+  customFields?: CustomField[] | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Activated at
    */
-  activatedAt: Date | null;
+  activatedAt?: Date | null;
   /**
    * Canceled at
    */
-  canceledAt: Date | null;
+  canceledAt?: Date | null;
   /**
    * Expires at
    */
-  expiresAt: Date | null;
+  expiresAt?: Date | null;
   /**
    * Recurring subscriptions paid with ACH will have this attribute set. This timestamp is used for alerting customers to reauthorize in 3 years in accordance with NACHA rules. If a subscription becomes inactive or the billing info is no longer a bank account, this timestamp is cleared.
    */
-  bankAccountAuthorizedAt: Date | null;
+  bankAccountAuthorizedAt?: Date | null;
 
 }
 
@@ -1602,13 +1602,13 @@ export interface SubscriptionShipping {
   /**
    * Object type
    */
-  object: string | null;
-  address: ShippingAddress | null;
-  method: ShippingMethodMini | null;
+  object?: string | null;
+  address?: ShippingAddress | null;
+  method?: ShippingMethodMini | null;
   /**
    * Subscription's shipping cost
    */
-  amount: number | null;
+  amount?: number | null;
 
 }
 
@@ -1616,19 +1616,19 @@ export interface ShippingMethodMini {
   /**
    * Shipping Method ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The internal name used identify the shipping method.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The name of the shipping method displayed to customers.
    */
-  name: string | null;
+  name?: string | null;
 
 }
 
@@ -1636,24 +1636,24 @@ export interface CouponRedemptionMini {
   /**
    * Coupon Redemption ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Will always be `coupon`.
    */
-  object: string | null;
-  coupon: CouponMini | null;
+  object?: string | null;
+  coupon?: CouponMini | null;
   /**
    * Invoice state
    */
-  state: string | null;
+  state?: string | null;
   /**
    * The amount that was discounted upon the application of the coupon, formatted with the currency.
    */
-  discounted: number | null;
+  discounted?: number | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
 
 }
 
@@ -1661,35 +1661,35 @@ export interface CouponMini {
   /**
    * Coupon ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The code the customer enters to redeem the coupon.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The internal name for the coupon.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Indicates if the coupon is redeemable, and if it is not, why.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * Details of the discount a coupon applies. Will contain a `type` property and one of the following properties: `percent`, `fixed`, `trial`. 
    */
-  discount: CouponDiscount | null;
+  discount?: CouponDiscount | null;
   /**
    * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  couponType: string | null;
+  couponType?: string | null;
   /**
    * The date and time the coupon was expired early or reached its `max_redemptions`.
    */
-  expiredAt: Date | null;
+  expiredAt?: Date | null;
 
 }
 
@@ -1697,63 +1697,63 @@ export interface SubscriptionChange {
   /**
    * The ID of the Subscription Change.
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The ID of the subscription that is going to be changed.
    */
-  subscriptionId: string | null;
+  subscriptionId?: string | null;
   /**
    * Just the important parts.
    */
-  plan: PlanMini | null;
+  plan?: PlanMini | null;
   /**
    * These add-ons will be used when the subscription renews.
    */
-  addOns: SubscriptionAddOn[] | null;
+  addOns?: SubscriptionAddOn[] | null;
   /**
    * Unit amount
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
   /**
    * Subscription quantity
    */
-  quantity: number | null;
+  quantity?: number | null;
   /**
    * Subscription shipping details
    */
-  shipping: SubscriptionShipping | null;
+  shipping?: SubscriptionShipping | null;
   /**
    * Activated at
    */
-  activateAt: Date | null;
+  activateAt?: Date | null;
   /**
    * Returns `true` if the subscription change is activated.
    */
-  activated: boolean | null;
+  activated?: boolean | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Setup fee revenue schedule type
    */
-  setupFeeRevenueScheduleType: string | null;
+  setupFeeRevenueScheduleType?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -1761,55 +1761,55 @@ export interface SubscriptionAddOn {
   /**
    * Subscription Add-on ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Subscription ID
    */
-  subscriptionId: string | null;
+  subscriptionId?: string | null;
   /**
    * Just the important parts.
    */
-  addOn: AddOnMini | null;
+  addOn?: AddOnMini | null;
   /**
    * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
    */
-  addOnSource: string | null;
+  addOnSource?: string | null;
   /**
    * Add-on quantity
    */
-  quantity: number | null;
+  quantity?: number | null;
   /**
    * This is priced in the subscription's currency.
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * The type of tiering used by the Add-on.
    */
-  tierType: string | null;
+  tierType?: string | null;
   /**
    * Empty unless `tier_type` is `tiered`, `volume`, or `stairstep`.
    */
-  tiers: SubscriptionAddOnTier[] | null;
+  tiers?: SubscriptionAddOnTier[] | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Expired at
    */
-  expiredAt: Date | null;
+  expiredAt?: Date | null;
 
 }
 
@@ -1817,31 +1817,31 @@ export interface AddOnMini {
   /**
    * Add-on ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The unique identifier for the add-on within its plan.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * Describes your add-on and will appear in subscribers' invoices.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Item ID
    */
-  itemId: string | null;
+  itemId?: string | null;
   /**
    * Optional, stock keeping unit to link the item to other inventory systems.
    */
-  externalSku: string | null;
+  externalSku?: string | null;
   /**
    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code.
    */
-  accountingCode: string | null;
+  accountingCode?: string | null;
 
 }
 
@@ -1849,11 +1849,11 @@ export interface SubscriptionAddOnTier {
   /**
    * Ending quantity
    */
-  endingQuantity: number | null;
+  endingQuantity?: number | null;
   /**
    * Unit amount
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
 
 }
 
@@ -1861,35 +1861,35 @@ export interface UniqueCouponCode {
   /**
    * Unique Coupon Code ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The code the customer enters to redeem the coupon.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * Indicates if the unique coupon code is redeemable or why not.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * The date and time the unique coupon code was redeemed.
    */
-  redeemedAt: Date | null;
+  redeemedAt?: Date | null;
   /**
    * The date and time the coupon was expired early or reached its `max_redemptions`.
    */
-  expiredAt: Date | null;
+  expiredAt?: Date | null;
 
 }
 
@@ -1897,43 +1897,43 @@ export interface CustomFieldDefinition {
   /**
    * Custom field definition ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Related Recurly object type
    */
-  relatedType: string | null;
+  relatedType?: string | null;
   /**
    * Used by the API to identify the field or reading and writing. The name can only be used once per Recurly object type.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * The access control applied inside Recurly's admin UI: - `api_only` - No one will be able to view or edit this field's data via the admin UI. - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but   editing will only be available via the API. - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI. 
    */
-  userAccess: string | null;
+  userAccess?: string | null;
   /**
    * Used to label the field when viewing and editing the field in Recurly's admin UI.
    */
-  displayName: string | null;
+  displayName?: string | null;
   /**
    * Displayed as a tooltip when editing the field in the Recurly admin UI.
    */
-  tooltip: string | null;
+  tooltip?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Definitions are initially soft deleted, and once all the values are removed from the accouts or subscriptions, will be hard deleted an no longer visible.
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -1941,67 +1941,67 @@ export interface Item {
   /**
    * Item ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Unique code to identify the item.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The current state of the item.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Optional, description.
    */
-  description: string | null;
+  description?: string | null;
   /**
    * Optional, stock keeping unit to link the item to other inventory systems.
    */
-  externalSku: string | null;
+  externalSku?: string | null;
   /**
    * Accounting code for invoice line items.
    */
-  accountingCode: string | null;
+  accountingCode?: string | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
    */
-  taxCode: string | null;
+  taxCode?: string | null;
   /**
    * `true` exempts tax on the item, `false` applies tax on the item.
    */
-  taxExempt: boolean | null;
+  taxExempt?: boolean | null;
   /**
    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
    */
-  customFields: CustomField[] | null;
+  customFields?: CustomField[] | null;
   /**
    * Item Pricing
    */
-  currencies: Pricing[] | null;
+  currencies?: Pricing[] | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -2009,16 +2009,16 @@ export interface Pricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Unit price
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
 
 }
 
 export interface BinaryFile {
-  data: string | null;
+  data?: string | null;
 
 }
 
@@ -2026,103 +2026,103 @@ export interface Plan {
   /**
    * Plan ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The current state of the plan.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Optional description, not displayed.
    */
-  description: string | null;
+  description?: string | null;
   /**
    * Unit for the plan's billing interval.
    */
-  intervalUnit: string | null;
+  intervalUnit?: string | null;
   /**
    * Length of the plan's billing interval in `interval_unit`.
    */
-  intervalLength: number | null;
+  intervalLength?: number | null;
   /**
    * Units for the plan's trial period.
    */
-  trialUnit: string | null;
+  trialUnit?: string | null;
   /**
    * Length of plan's trial period in `trial_units`. `0` means `no trial`.
    */
-  trialLength: number | null;
+  trialLength?: number | null;
   /**
    * Allow free trial subscriptions to be created without billing info.
    */
-  trialRequiresBillingInfo: boolean | null;
+  trialRequiresBillingInfo?: boolean | null;
   /**
    * Automatically terminate subscriptions after a defined number of billing cycles. Number of billing cycles before the plan automatically stops renewing, defaults to `null` for continuous, automatic renewal.
    */
-  totalBillingCycles: number | null;
+  totalBillingCycles?: number | null;
   /**
    * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
    */
-  autoRenew: boolean | null;
+  autoRenew?: boolean | null;
   /**
    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
    */
-  accountingCode: string | null;
+  accountingCode?: string | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Setup fee revenue schedule type
    */
-  setupFeeRevenueScheduleType: string | null;
+  setupFeeRevenueScheduleType?: string | null;
   /**
    * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
    */
-  setupFeeAccountingCode: string | null;
+  setupFeeAccountingCode?: string | null;
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
    */
-  taxCode: string | null;
+  taxCode?: string | null;
   /**
    * `true` exempts tax on the plan, `false` applies tax on the plan.
    */
-  taxExempt: boolean | null;
+  taxExempt?: boolean | null;
   /**
    * Pricing
    */
-  currencies: PlanPricing[] | null;
+  currencies?: PlanPricing[] | null;
   /**
    * Hosted pages settings
    */
-  hostedPages: PlanHostedPages | null;
+  hostedPages?: PlanHostedPages | null;
   /**
    * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
    */
-  allowAnyItemOnSubscriptions: boolean | null;
+  allowAnyItemOnSubscriptions?: boolean | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -2130,15 +2130,15 @@ export interface PlanPricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
    */
-  setupFee: number | null;
+  setupFee?: number | null;
   /**
    * Unit price
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
 
 }
 
@@ -2146,19 +2146,19 @@ export interface PlanHostedPages {
   /**
    * URL to redirect to after signup on the hosted payment pages.
    */
-  successUrl: string | null;
+  successUrl?: string | null;
   /**
    * URL to redirect to on canceled signup on the hosted payment pages.
    */
-  cancelUrl: string | null;
+  cancelUrl?: string | null;
   /**
    * If `true`, the customer will be sent directly to your `success_url` after a successful signup, bypassing Recurly's hosted confirmation page.
    */
-  bypassConfirmation: boolean | null;
+  bypassConfirmation?: boolean | null;
   /**
    * Determines if the quantity field is displayed on the hosted pages for the plan.
    */
-  displayQuantity: boolean | null;
+  displayQuantity?: boolean | null;
 
 }
 
@@ -2166,83 +2166,83 @@ export interface AddOn {
   /**
    * Add-on ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Plan ID
    */
-  planId: string | null;
+  planId?: string | null;
   /**
    * The unique identifier for the add-on within its plan.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * Add-ons can be either active or inactive.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * Describes your add-on and will appear in subscribers' invoices.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code.
    */
-  accountingCode: string | null;
+  accountingCode?: string | null;
   /**
    * When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
    */
-  taxCode: string | null;
+  taxCode?: string | null;
   /**
    * Determines if the quantity field is displayed on the hosted pages for the add-on.
    */
-  displayQuantity: boolean | null;
+  displayQuantity?: boolean | null;
   /**
    * Default quantity for the hosted pages.
    */
-  defaultQuantity: number | null;
+  defaultQuantity?: number | null;
   /**
    * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
    */
-  optional: boolean | null;
+  optional?: boolean | null;
   /**
    * Add-on pricing
    */
-  currencies: AddOnPricing[] | null;
+  currencies?: AddOnPricing[] | null;
   /**
    * Just the important parts.
    */
-  item: ItemMini | null;
+  item?: ItemMini | null;
   /**
    * The type of tiering used by the Add-on.
    */
-  tierType: string | null;
+  tierType?: string | null;
   /**
    * Tiers
    */
-  tiers: Tier[] | null;
+  tiers?: Tier[] | null;
   /**
    * Optional, stock keeping unit to link the item to other inventory systems.
    */
-  externalSku: string | null;
+  externalSku?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -2250,11 +2250,11 @@ export interface AddOnPricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
-  currency: string | null;
+  currency?: string | null;
   /**
    * Unit price
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
 
 }
 
@@ -2262,27 +2262,27 @@ export interface ItemMini {
   /**
    * Item ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * Unique code to identify the item.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The current state of the item.
    */
-  state: string | null;
+  state?: string | null;
   /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Optional, description.
    */
-  description: string | null;
+  description?: string | null;
 
 }
 
@@ -2290,11 +2290,11 @@ export interface Tier {
   /**
    * Ending quantity
    */
-  endingQuantity: number | null;
+  endingQuantity?: number | null;
   /**
    * Tier pricing
    */
-  currencies: Pricing[] | null;
+  currencies?: Pricing[] | null;
 
 }
 
@@ -2302,39 +2302,39 @@ export interface ShippingMethod {
   /**
    * Shipping Method ID
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The internal name used identify the shipping method.
    */
-  code: string | null;
+  code?: string | null;
   /**
    * The name of the shipping method displayed to customers.
    */
-  name: string | null;
+  name?: string | null;
   /**
    * Accounting code for shipping method.
    */
-  accountingCode: string | null;
+  accountingCode?: string | null;
   /**
    * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
    */
-  taxCode: string | null;
+  taxCode?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Last updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -2342,67 +2342,67 @@ export interface SubscriptionChangePreview {
   /**
    * Invoice collection
    */
-  invoiceCollection: InvoiceCollection | null;
+  invoiceCollection?: InvoiceCollection | null;
   /**
    * The ID of the Subscription Change.
    */
-  id: string | null;
+  id?: string | null;
   /**
    * Object type
    */
-  object: string | null;
+  object?: string | null;
   /**
    * The ID of the subscription that is going to be changed.
    */
-  subscriptionId: string | null;
+  subscriptionId?: string | null;
   /**
    * Just the important parts.
    */
-  plan: PlanMini | null;
+  plan?: PlanMini | null;
   /**
    * These add-ons will be used when the subscription renews.
    */
-  addOns: SubscriptionAddOn[] | null;
+  addOns?: SubscriptionAddOn[] | null;
   /**
    * Unit amount
    */
-  unitAmount: number | null;
+  unitAmount?: number | null;
   /**
    * Subscription quantity
    */
-  quantity: number | null;
+  quantity?: number | null;
   /**
    * Subscription shipping details
    */
-  shipping: SubscriptionShipping | null;
+  shipping?: SubscriptionShipping | null;
   /**
    * Activated at
    */
-  activateAt: Date | null;
+  activateAt?: Date | null;
   /**
    * Returns `true` if the subscription change is activated.
    */
-  activated: boolean | null;
+  activated?: boolean | null;
   /**
    * Revenue schedule type
    */
-  revenueScheduleType: string | null;
+  revenueScheduleType?: string | null;
   /**
    * Setup fee revenue schedule type
    */
-  setupFeeRevenueScheduleType: string | null;
+  setupFeeRevenueScheduleType?: string | null;
   /**
    * Created at
    */
-  createdAt: Date | null;
+  createdAt?: Date | null;
   /**
    * Updated at
    */
-  updatedAt: Date | null;
+  updatedAt?: Date | null;
   /**
    * Deleted at
    */
-  deletedAt: Date | null;
+  deletedAt?: Date | null;
 
 }
 
@@ -2417,6 +2417,1829 @@ export declare class Pager<T> {
   each(): AsyncIterable<T>;
   eachPage(): AsyncIterable<T>;
 }
+
+export interface AccountCreate {
+  /**
+   * The unique identifier of the account. This cannot be changed once the account is created.
+   */
+  code?: string | null;
+  acquisition?: AccountAcquisitionUpdatable | null;
+  shippingAddresses?: ShippingAddressCreate[] | null;
+  /**
+   * A secondary value for the account.
+   */
+  username?: string | null;
+  /**
+   * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
+   */
+  email?: string | null;
+  /**
+   * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
+   */
+  preferredLocale?: string | null;
+  /**
+   * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
+   */
+  ccEmails?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  /**
+   * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
+   */
+  vatNumber?: string | null;
+  /**
+   * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
+   */
+  exemptionCertificate?: string | null;
+  /**
+   * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+   */
+  parentAccountCode?: string | null;
+  /**
+   * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+   */
+  parentAccountId?: string | null;
+  /**
+   * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
+   */
+  billTo?: string | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+  address?: Address | null;
+  billingInfo?: BillingInfoCreate | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+
+}
+
+export interface AccountAcquisitionUpdatable {
+  /**
+   * Account balance
+   */
+  cost?: AccountAcquisitionCost | null;
+  /**
+   * The channel through which the account was acquired.
+   */
+  channel?: string | null;
+  /**
+   * An arbitrary subchannel string representing a distinction/subcategory within a broader channel.
+   */
+  subchannel?: string | null;
+  /**
+   * An arbitrary identifier for the marketing campaign that led to the acquisition of this account.
+   */
+  campaign?: string | null;
+
+}
+
+export interface AccountAcquisitionCost {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * The amount of the corresponding currency used to acquire the account.
+   */
+  amount?: number | null;
+
+}
+
+export interface ShippingAddressCreate {
+  nickname?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  email?: string | null;
+  vatNumber?: string | null;
+  phone?: string | null;
+  street1?: string | null;
+  street2?: string | null;
+  city?: string | null;
+  /**
+   * State or province.
+   */
+  region?: string | null;
+  /**
+   * Zip or postal code.
+   */
+  postalCode?: string | null;
+  /**
+   * Country, 2-letter ISO code.
+   */
+  country?: string | null;
+
+}
+
+export interface Address {
+  /**
+   * First name
+   */
+  firstName?: string | null;
+  /**
+   * Last name
+   */
+  lastName?: string | null;
+  /**
+   * Phone number
+   */
+  phone?: string | null;
+  /**
+   * Street 1
+   */
+  street1?: string | null;
+  /**
+   * Street 2
+   */
+  street2?: string | null;
+  /**
+   * City
+   */
+  city?: string | null;
+  /**
+   * State or province.
+   */
+  region?: string | null;
+  /**
+   * Zip or postal code.
+   */
+  postalCode?: string | null;
+  /**
+   * Country, 2-letter ISO code.
+   */
+  country?: string | null;
+
+}
+
+export interface BillingInfoCreate {
+  /**
+   * A token [generated by Recurly.js](https://developers.recurly.com/reference/recurly-js/#getting-a-token).
+   */
+  tokenId?: string | null;
+  /**
+   * First name
+   */
+  firstName?: string | null;
+  /**
+   * Last name
+   */
+  lastName?: string | null;
+  /**
+   * Company name
+   */
+  company?: string | null;
+  address?: Address | null;
+  /**
+   * Credit card number, spaces and dashes are accepted.
+   */
+  number?: string | null;
+  /**
+   * Expiration month
+   */
+  month?: string | null;
+  /**
+   * Expiration year
+   */
+  year?: string | null;
+  /**
+   * *STRONGLY RECOMMENDED*
+   */
+  cvv?: string | null;
+  /**
+   * VAT number
+   */
+  vatNumber?: string | null;
+  /**
+   * *STRONGLY RECOMMENDED* Customer's IP address when updating their billing information.
+   */
+  ipAddress?: string | null;
+  /**
+   * A token used in place of a credit card in order to perform transactions. Must be used in conjunction with `gateway_code`.
+   */
+  gatewayToken?: string | null;
+  /**
+   * An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.
+   */
+  gatewayCode?: string | null;
+  /**
+   * Amazon billing agreement ID
+   */
+  amazonBillingAgreementId?: string | null;
+  /**
+   * PayPal billing agreement ID
+   */
+  paypalBillingAgreementId?: string | null;
+  /**
+   * Fraud Session ID
+   */
+  fraudSessionId?: string | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+  /**
+   * A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
+   */
+  threeDSecureActionResultTokenId?: string | null;
+  /**
+   * The International Bank Account Number, up to 34 alphanumeric characters comprising a country code; two check digits; and a number that includes the domestic bank account number, branch identifier, and potential routing information. (SEPA only)
+   */
+  iban?: string | null;
+  /**
+   * The name associated with the bank account (ACH, SEPA, Bacs only)
+   */
+  nameOnAccount?: string | null;
+  /**
+   * The bank account number. (ACH, Bacs only)
+   */
+  accountNumber?: string | null;
+  /**
+   * The bank's rounting number. (ACH only)
+   */
+  routingNumber?: string | null;
+  /**
+   * Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
+   */
+  sortCode?: string | null;
+  /**
+   * The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+   */
+  type?: string | null;
+  /**
+   * The bank account type. (ACH only)
+   */
+  accountType?: string | null;
+
+}
+
+export interface CustomField {
+  /**
+   * Fields must be created in the UI before values can be assigned to them.
+   */
+  name?: string | null;
+  /**
+   * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
+   */
+  value?: string | null;
+
+}
+
+export interface AccountUpdate {
+  /**
+   * A secondary value for the account.
+   */
+  username?: string | null;
+  /**
+   * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
+   */
+  email?: string | null;
+  /**
+   * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
+   */
+  preferredLocale?: string | null;
+  /**
+   * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
+   */
+  ccEmails?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  /**
+   * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
+   */
+  vatNumber?: string | null;
+  /**
+   * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
+   */
+  exemptionCertificate?: string | null;
+  /**
+   * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+   */
+  parentAccountCode?: string | null;
+  /**
+   * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+   */
+  parentAccountId?: string | null;
+  /**
+   * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
+   */
+  billTo?: string | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+  address?: Address | null;
+  billingInfo?: BillingInfoCreate | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+
+}
+
+export interface CouponRedemptionCreate {
+  /**
+   * Coupon ID
+   */
+  couponId?: string | null;
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+
+}
+
+export interface InvoiceCreate {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * An automatic invoice means a corresponding transaction is run using the account's billing information at the same time the invoice is created. Manual invoices are created without a corresponding transaction. The merchant must enter a manual payment transaction or have the customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH bank payment.
+   */
+  collectionMethod?: string | null;
+  /**
+   * This will default to the Customer Notes text specified on the Invoice Settings for charge invoices. Specify custom notes to add or override Customer Notes on charge invoices.
+   */
+  chargeCustomerNotes?: string | null;
+  /**
+   * This will default to the Customer Notes text specified on the Invoice Settings for credit invoices. Specify customer notes to add or override Customer Notes on credit invoices.
+   */
+  creditCustomerNotes?: string | null;
+  /**
+   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   */
+  netTerms?: number | null;
+  /**
+   * For manual invoicing, this identifies the PO number associated with the subscription.
+   */
+  poNumber?: string | null;
+  /**
+   * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions.
+   */
+  termsAndConditions?: string | null;
+  /**
+   * VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
+   */
+  vatReverseChargeNotes?: string | null;
+
+}
+
+export interface LineItemCreate {
+  /**
+   * 3-letter ISO 4217 currency code. If `item_code`/`item_id` is part of the request then `currency` is optional, if the site has a single default currency. `currency` is required if `item_code`/`item_id` is present, and there are multiple currencies defined on the site. If `item_code`/`item_id` is not present `currency` is required.
+   */
+  currency?: string | null;
+  /**
+   * A positive or negative amount with `type=charge` will result in a positive `unit_amount`. A positive or negative amount with `type=credit` will result in a negative `unit_amount`. If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required. 
+   */
+  unitAmount?: number | null;
+  /**
+   * This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
+   */
+  quantity?: number | null;
+  /**
+   * Description that appears on the invoice. If `item_code`/`item_id` is part of the request then `description` must be absent.
+   */
+  description?: string | null;
+  /**
+   * Unique code to identify an item. Avaliable when the Credit Invoices and Subscription Billing Terms features are enabled.
+   */
+  itemCode?: string | null;
+  /**
+   * System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+   */
+  itemId?: string | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If `item_code`/`item_id` is not present then `type` is required.
+   */
+  type?: string | null;
+  /**
+   * The reason the credit was given when line item is `type=credit`. When the Credit Invoices feature is enabled, the value can be set and will default to `general`. When the Credit Invoices feature is not enabled, the value will always be `null`.
+   */
+  creditReasonCode?: string | null;
+  /**
+   * Accounting Code for the `LineItem`. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
+   */
+  accountingCode?: string | null;
+  /**
+   * `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+   */
+  taxCode?: string | null;
+  /**
+   * Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.
+   */
+  productCode?: string | null;
+  /**
+   * Only allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Can only have a value of `external_gift_card`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.
+   */
+  origin?: string | null;
+  /**
+   * If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date. Defaults to the current date-time.
+   */
+  startDate?: Date | null;
+  /**
+   * If this date is provided, it indicates the end of a time range.
+   */
+  endDate?: Date | null;
+
+}
+
+export interface ShippingAddressUpdate {
+  /**
+   * Shipping Address ID
+   */
+  id?: string | null;
+  nickname?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  email?: string | null;
+  vatNumber?: string | null;
+  phone?: string | null;
+  street1?: string | null;
+  street2?: string | null;
+  city?: string | null;
+  /**
+   * State or province.
+   */
+  region?: string | null;
+  /**
+   * Zip or postal code.
+   */
+  postalCode?: string | null;
+  /**
+   * Country, 2-letter ISO code.
+   */
+  country?: string | null;
+
+}
+
+export interface CouponCreate {
+  /**
+   * The internal name for the coupon.
+   */
+  name?: string | null;
+  /**
+   * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
+   */
+  maxRedemptions?: number | null;
+  /**
+   * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
+   */
+  maxRedemptionsPerAccount?: number | null;
+  /**
+   * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
+   */
+  hostedDescription?: string | null;
+  /**
+   * Description of the coupon on the invoice.
+   */
+  invoiceDescription?: string | null;
+  /**
+   * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
+   */
+  redeemByDate?: string | null;
+  /**
+   * The code the customer enters to redeem the coupon.
+   */
+  code?: string | null;
+  /**
+   * The type of discount provided by the coupon (how the amount discounted is calculated)
+   */
+  discountType?: string | null;
+  /**
+   * The percent of the price discounted by the coupon.  Required if `discount_type` is `percent`.
+   */
+  discountPercent?: number | null;
+  /**
+   * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine the duration of time the coupon is for.  Required if `discount_type` is `free_trial`.
+   */
+  freeTrialUnit?: string | null;
+  /**
+   * Sets the duration of time the `free_trial_unit` is for. Required if `discount_type` is `free_trial`.
+   */
+  freeTrialAmount?: number | null;
+  /**
+   * Fixed discount currencies by currency. Required if the coupon type is `fixed`. This parameter should contain the coupon discount values
+   */
+  currencies?: CouponPricing[] | null;
+  /**
+   * The coupon is valid for one-time, non-plan charges if true.
+   */
+  appliesToNonPlanCharges?: boolean | null;
+  /**
+   * The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans.
+   */
+  appliesToAllPlans?: boolean | null;
+  /**
+   * List of plan codes to which this coupon applies. See `applies_to_all_plans`
+   */
+  planCodes?: string[] | null;
+  /**
+   * This field does not apply when the discount_type is `free_trial`. - "single_use" coupons applies to the first invoice only. - "temporal" coupons will apply to invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes. - "forever" coupons will apply to invoices forever. 
+   */
+  duration?: string | null;
+  /**
+   * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+   */
+  temporalAmount?: number | null;
+  /**
+   * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+   */
+  temporalUnit?: string | null;
+  /**
+   * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
+   */
+  couponType?: string | null;
+  /**
+   * On a bulk coupon, the template from which unique coupon codes are generated. - You must start the template with your coupon_code wrapped in single quotes. - Outside of single quotes, use a 9 for a character that you want to be a random number. - Outside of single quotes, use an "x" for a character that you want to be a random letter. - Outside of single quotes, use an * for a character that you want to be a random number or letter. - Use single quotes ' ' for characters that you want to remain static. These strings can be alphanumeric and may contain a - _ or +. For example: "'abc-'****'-def'" 
+   */
+  uniqueCodeTemplate?: string | null;
+  /**
+   * Whether the discount is for all eligible charges on the account, or only a specific subscription.
+   */
+  redemptionResource?: string | null;
+
+}
+
+export interface CouponPricing {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * The fixed discount (in dollars) for the corresponding currency.
+   */
+  discount?: number | null;
+
+}
+
+export interface CouponUpdate {
+  /**
+   * The internal name for the coupon.
+   */
+  name?: string | null;
+  /**
+   * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
+   */
+  maxRedemptions?: number | null;
+  /**
+   * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
+   */
+  maxRedemptionsPerAccount?: number | null;
+  /**
+   * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
+   */
+  hostedDescription?: string | null;
+  /**
+   * Description of the coupon on the invoice.
+   */
+  invoiceDescription?: string | null;
+  /**
+   * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
+   */
+  redeemByDate?: string | null;
+
+}
+
+export interface CouponBulkCreate {
+  /**
+   * The quantity of unique coupon codes to generate
+   */
+  numberOfUniqueCodes?: number | null;
+
+}
+
+export interface ItemCreate {
+  /**
+   * Unique code to identify the item.
+   */
+  code?: string | null;
+  /**
+   * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
+   */
+  name?: string | null;
+  /**
+   * Optional, description.
+   */
+  description?: string | null;
+  /**
+   * Optional, stock keeping unit to link the item to other inventory systems.
+   */
+  externalSku?: string | null;
+  /**
+   * Accounting code for invoice line items.
+   */
+  accountingCode?: string | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+   */
+  taxCode?: string | null;
+  /**
+   * `true` exempts tax on the item, `false` applies tax on the item.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+  /**
+   * Item Pricing
+   */
+  currencies?: Pricing[] | null;
+
+}
+
+export interface Pricing {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * Unit price
+   */
+  unitAmount?: number | null;
+
+}
+
+export interface ItemUpdate {
+  /**
+   * Unique code to identify the item.
+   */
+  code?: string | null;
+  /**
+   * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
+   */
+  name?: string | null;
+  /**
+   * Optional, description.
+   */
+  description?: string | null;
+  /**
+   * Optional, stock keeping unit to link the item to other inventory systems.
+   */
+  externalSku?: string | null;
+  /**
+   * Accounting code for invoice line items.
+   */
+  accountingCode?: string | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+   */
+  taxCode?: string | null;
+  /**
+   * `true` exempts tax on the item, `false` applies tax on the item.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+  /**
+   * Item Pricing
+   */
+  currencies?: Pricing[] | null;
+
+}
+
+export interface InvoiceUpdatable {
+  /**
+   * This identifies the PO number associated with the invoice. Not editable for credit invoices.
+   */
+  poNumber?: string | null;
+  /**
+   * VAT Reverse Charge Notes are editable only if there was a VAT reverse charge applied to the invoice.
+   */
+  vatReverseChargeNotes?: string | null;
+  /**
+   * Terms and conditions are an optional note field. Not editable for credit invoices.
+   */
+  termsAndConditions?: string | null;
+  /**
+   * Customer notes are an optional note field.
+   */
+  customerNotes?: string | null;
+  /**
+   * Integer representing the number of days after an invoice's creation that the invoice will become past due. Changing Net terms changes due_on, and the invoice could move between past due and pending.
+   */
+  netTerms?: number | null;
+  address?: InvoiceAddress | null;
+
+}
+
+export interface InvoiceAddress {
+  /**
+   * Name on account
+   */
+  nameOnAccount?: string | null;
+  /**
+   * Company
+   */
+  company?: string | null;
+  /**
+   * First name
+   */
+  firstName?: string | null;
+  /**
+   * Last name
+   */
+  lastName?: string | null;
+  /**
+   * Phone number
+   */
+  phone?: string | null;
+  /**
+   * Street 1
+   */
+  street1?: string | null;
+  /**
+   * Street 2
+   */
+  street2?: string | null;
+  /**
+   * City
+   */
+  city?: string | null;
+  /**
+   * State or province.
+   */
+  region?: string | null;
+  /**
+   * Zip or postal code.
+   */
+  postalCode?: string | null;
+  /**
+   * Country, 2-letter ISO code.
+   */
+  country?: string | null;
+
+}
+
+export interface InvoiceCollect {
+  /**
+   * A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
+   */
+  threeDSecureActionResultTokenId?: string | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+
+}
+
+export interface ExternalTransaction {
+  /**
+   * Payment method used for the external transaction.
+   */
+  paymentMethod?: string | null;
+  /**
+   * Used as the transaction's description.
+   */
+  description?: string | null;
+  /**
+   * The total amount of the transcaction. Cannot excceed the invoice total.
+   */
+  amount?: number | null;
+  /**
+   * Datetime that the external payment was collected. Defaults to current datetime.
+   */
+  collectedAt?: Date | null;
+
+}
+
+export interface InvoiceRefund {
+  /**
+   * The type of refund. Amount and line items cannot both be specified in the request.
+   */
+  type?: string | null;
+  /**
+   * The amount to be refunded. The amount will be split between the line items. If no amount is specified, it will default to refunding the total refundable amount on the invoice. 
+   */
+  amount?: number | null;
+  /**
+   * The line items to be refunded. This is required when `type=line_items`.
+   */
+  lineItems?: LineItemRefund[] | null;
+  /**
+   * Indicates how the invoice should be refunded when both a credit and transaction are present on the invoice: - `transaction_first` – Refunds the transaction first, then any amount is issued as credit back to the account. Default value when Credit Invoices feature is enabled. - `credit_first` – Issues credit back to the account first, then refunds any remaining amount back to the transaction. Default value when Credit Invoices feature is not enabled. - `all_credit` – Issues credit to the account for the entire amount of the refund. Only available when the Credit Invoices feature is enabled. - `all_transaction` – Refunds the entire amount back to transactions, using transactions from previous invoices if necessary. Only available when the Credit Invoices feature is enabled. 
+   */
+  refundMethod?: string | null;
+  /**
+   * Used as the Customer Notes on the credit invoice.  This field can only be include when the Credit Invoices feature is enabled. 
+   */
+  creditCustomerNotes?: string | null;
+  /**
+   * Indicates that the refund was settled outside of Recurly, and a manual transaction should be created to track it in Recurly.  Required when: - refunding a manually collected charge invoice, and `refund_method` is not `all_credit` - refunding a credit invoice that refunded manually collecting invoices - refunding a credit invoice for a partial amount  This field can only be included when the Credit Invoices feature is enabled. 
+   */
+  externalRefund?: ExternalRefund | null;
+
+}
+
+export interface LineItemRefund {
+  /**
+   * Line item ID
+   */
+  id?: string | null;
+  /**
+   * Line item quantity to be refunded.
+   */
+  quantity?: number | null;
+  /**
+   * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used on line items that have a start and end date. 
+   */
+  prorate?: boolean | null;
+
+}
+
+export interface ExternalRefund {
+  /**
+   * Payment method used for external refund transaction.
+   */
+  paymentMethod?: string | null;
+  /**
+   * Used as the refund transactions' description.
+   */
+  description?: string | null;
+  /**
+   * Date the external refund payment was made. Defaults to the current date-time.
+   */
+  refundedAt?: Date | null;
+
+}
+
+export interface PlanCreate {
+  /**
+   * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
+   */
+  code?: string | null;
+  /**
+   * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
+   */
+  name?: string | null;
+  /**
+   * Optional description, not displayed.
+   */
+  description?: string | null;
+  /**
+   * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
+   */
+  accountingCode?: string | null;
+  /**
+   * Unit for the plan's billing interval.
+   */
+  intervalUnit?: string | null;
+  /**
+   * Length of the plan's billing interval in `interval_unit`.
+   */
+  intervalLength?: number | null;
+  /**
+   * Units for the plan's trial period.
+   */
+  trialUnit?: string | null;
+  /**
+   * Length of plan's trial period in `trial_units`. `0` means `no trial`.
+   */
+  trialLength?: number | null;
+  /**
+   * Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
+   */
+  trialRequiresBillingInfo?: boolean | null;
+  /**
+   * Automatically terminate plans after a defined number of billing cycles.
+   */
+  totalBillingCycles?: number | null;
+  /**
+   * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
+   */
+  autoRenew?: boolean | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Setup fee revenue schedule type
+   */
+  setupFeeRevenueScheduleType?: string | null;
+  /**
+   * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
+   */
+  setupFeeAccountingCode?: string | null;
+  /**
+   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+   */
+  taxCode?: string | null;
+  /**
+   * `true` exempts tax on the plan, `false` applies tax on the plan.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * Pricing
+   */
+  currencies?: PlanPricing[] | null;
+  /**
+   * Hosted pages settings
+   */
+  hostedPages?: PlanHostedPages | null;
+  /**
+   * Add Ons
+   */
+  addOns?: AddOnCreate[] | null;
+  /**
+   * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
+   */
+  allowAnyItemOnSubscriptions?: boolean | null;
+
+}
+
+export interface PlanPricing {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
+   */
+  setupFee?: number | null;
+  /**
+   * Unit price
+   */
+  unitAmount?: number | null;
+
+}
+
+export interface PlanHostedPages {
+  /**
+   * URL to redirect to after signup on the hosted payment pages.
+   */
+  successUrl?: string | null;
+  /**
+   * URL to redirect to on canceled signup on the hosted payment pages.
+   */
+  cancelUrl?: string | null;
+  /**
+   * If `true`, the customer will be sent directly to your `success_url` after a successful signup, bypassing Recurly's hosted confirmation page.
+   */
+  bypassConfirmation?: boolean | null;
+  /**
+   * Determines if the quantity field is displayed on the hosted pages for the plan.
+   */
+  displayQuantity?: boolean | null;
+
+}
+
+export interface AddOnCreate {
+  /**
+   * Unique code to identify an item. Avaliable when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+   */
+  itemCode?: string | null;
+  /**
+   * System-generated unique identifier for an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+   */
+  itemId?: string | null;
+  /**
+   * The unique identifier for the add-on within its plan. If `item_code`/`item_id` is part of the request then `code` must be absent. If `item_code`/`item_id` is not present `code` is required.
+   */
+  code?: string | null;
+  /**
+   * Describes your add-on and will appear in subscribers' invoices. If `item_code`/`item_id` is part of the request then `name` must be absent. If `item_code`/`item_id` is not present `name` is required.
+   */
+  name?: string | null;
+  /**
+   * Plan ID
+   */
+  planId?: string | null;
+  /**
+   * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
+   */
+  accountingCode?: string | null;
+  /**
+   * When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Determines if the quantity field is displayed on the hosted pages for the add-on.
+   */
+  displayQuantity?: boolean | null;
+  /**
+   * Default quantity for the hosted pages.
+   */
+  defaultQuantity?: number | null;
+  /**
+   * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
+   */
+  optional?: boolean | null;
+  /**
+   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
+   */
+  taxCode?: string | null;
+  /**
+   * * If `item_code`/`item_id` is part of the request and the item has a default currency then `currencies` is optional. If the item does not have a default currency, then `currencies` is required. If `item_code`/`item_id` is not present `currencies` is required. * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. 
+   */
+  currencies?: AddOnPricing[] | null;
+  /**
+   * The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). 
+   */
+  tierType?: string | null;
+  /**
+   * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+   */
+  tiers?: Tier[] | null;
+
+}
+
+export interface AddOnPricing {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * Unit price
+   */
+  unitAmount?: number | null;
+
+}
+
+export interface Tier {
+  /**
+   * Ending quantity
+   */
+  endingQuantity?: number | null;
+  /**
+   * Tier pricing
+   */
+  currencies?: Pricing[] | null;
+
+}
+
+export interface PlanUpdate {
+  /**
+   * Plan ID
+   */
+  id?: string | null;
+  /**
+   * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
+   */
+  code?: string | null;
+  /**
+   * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
+   */
+  name?: string | null;
+  /**
+   * Optional description, not displayed.
+   */
+  description?: string | null;
+  /**
+   * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
+   */
+  accountingCode?: string | null;
+  /**
+   * Units for the plan's trial period.
+   */
+  trialUnit?: string | null;
+  /**
+   * Length of plan's trial period in `trial_units`. `0` means `no trial`.
+   */
+  trialLength?: number | null;
+  /**
+   * Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
+   */
+  trialRequiresBillingInfo?: boolean | null;
+  /**
+   * Automatically terminate plans after a defined number of billing cycles.
+   */
+  totalBillingCycles?: number | null;
+  /**
+   * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
+   */
+  autoRenew?: boolean | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Setup fee revenue schedule type
+   */
+  setupFeeRevenueScheduleType?: string | null;
+  /**
+   * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
+   */
+  setupFeeAccountingCode?: string | null;
+  /**
+   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+   */
+  taxCode?: string | null;
+  /**
+   * `true` exempts tax on the plan, `false` applies tax on the plan.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * Pricing
+   */
+  currencies?: PlanPricing[] | null;
+  /**
+   * Hosted pages settings
+   */
+  hostedPages?: PlanHostedPages | null;
+  /**
+   * Add Ons
+   */
+  addOns?: AddOnCreate[] | null;
+  /**
+   * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
+   */
+  allowAnyItemOnSubscriptions?: boolean | null;
+
+}
+
+export interface AddOnUpdate {
+  /**
+   * Add-on ID
+   */
+  id?: string | null;
+  /**
+   * The unique identifier for the add-on within its plan. If an `Item` is associated to the `AddOn` then `code` must be absent.
+   */
+  code?: string | null;
+  /**
+   * Describes your add-on and will appear in subscribers' invoices. If an `Item` is associated to the `AddOn` then `name` must be absent.
+   */
+  name?: string | null;
+  /**
+   * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If an `Item` is associated to the `AddOn` then `accounting code` must be absent.
+   */
+  accountingCode?: string | null;
+  /**
+   * When this add-on is invoiced, the line item will use this revenue schedule. If an `Item` is associated to the `AddOn` then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If an `Item` is associated to the `AddOn` then `tax code` must be absent.
+   */
+  taxCode?: string | null;
+  /**
+   * Determines if the quantity field is displayed on the hosted pages for the add-on.
+   */
+  displayQuantity?: boolean | null;
+  /**
+   * Default quantity for the hosted pages.
+   */
+  defaultQuantity?: number | null;
+  /**
+   * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
+   */
+  optional?: boolean | null;
+  /**
+   * If the add-on's `tier_type` is `tiered`, `volume` or `stairstep`, then `currencies` must be absent. 
+   */
+  currencies?: AddOnPricing[] | null;
+  /**
+   * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+   */
+  tiers?: Tier[] | null;
+
+}
+
+export interface ShippingMethodCreate {
+  /**
+   * The internal name used identify the shipping method.
+   */
+  code?: string | null;
+  /**
+   * The name of the shipping method displayed to customers.
+   */
+  name?: string | null;
+  /**
+   * Accounting code for shipping method.
+   */
+  accountingCode?: string | null;
+  /**
+   * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
+   */
+  taxCode?: string | null;
+
+}
+
+export interface ShippingMethodUpdate {
+  /**
+   * The internal name used identify the shipping method.
+   */
+  code?: string | null;
+  /**
+   * The name of the shipping method displayed to customers.
+   */
+  name?: string | null;
+  /**
+   * Accounting code for shipping method.
+   */
+  accountingCode?: string | null;
+  /**
+   * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
+   */
+  taxCode?: string | null;
+
+}
+
+export interface SubscriptionCreate {
+  /**
+   * You must provide either a `plan_code` or `plan_id`. If both are provided the `plan_id` will be used.
+   */
+  planCode?: string | null;
+  /**
+   * You must provide either a `plan_code` or `plan_id`. If both are provided the `plan_id` will be used.
+   */
+  planId?: string | null;
+  account?: AccountCreate | null;
+  /**
+   * Create a shipping address on the account and assign it to the subscription.
+   */
+  shipping?: SubscriptionShippingCreate | null;
+  /**
+   * Collection method
+   */
+  collectionMethod?: string | null;
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  /**
+   * Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
+   */
+  unitAmount?: number | null;
+  /**
+   * Optionally override the default quantity of 1.
+   */
+  quantity?: number | null;
+  /**
+   * Add-ons
+   */
+  addOns?: SubscriptionAddOnCreate[] | null;
+  /**
+   * Optional coupon code to redeem on the account and discount the subscription. Please note, the subscription request will fail if the coupon is invalid.
+   */
+  couponCode?: string | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+  /**
+   * If set, overrides the default trial behavior for the subscription. The date must be in the future.
+   */
+  trialEndsAt?: Date | null;
+  /**
+   * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+   */
+  startsAt?: Date | null;
+  /**
+   * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.
+   */
+  nextBillDate?: Date | null;
+  /**
+   * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
+   */
+  totalBillingCycles?: number | null;
+  /**
+   * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
+   */
+  renewalBillingCycles?: number | null;
+  /**
+   * Whether the subscription renews at the end of its term.
+   */
+  autoRenew?: boolean | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
+   */
+  termsAndConditions?: string | null;
+  /**
+   * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.
+   */
+  customerNotes?: string | null;
+  /**
+   * If there are pending credits on the account that will be invoiced during the subscription creation, these will be used as the Customer Notes on the credit invoice.
+   */
+  creditCustomerNotes?: string | null;
+  /**
+   * For manual invoicing, this identifies the PO number associated with the subscription.
+   */
+  poNumber?: string | null;
+  /**
+   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   */
+  netTerms?: number | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+
+}
+
+export interface SubscriptionShippingCreate {
+  address?: ShippingAddressCreate | null;
+  /**
+   * Assign a shipping address from the account's existing shipping addresses. If `address_id` and `address` are both present, `address` will be used.
+   */
+  addressId?: string | null;
+  /**
+   * The id of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodId?: string | null;
+  /**
+   * The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodCode?: string | null;
+  /**
+   * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
+   */
+  amount?: number | null;
+
+}
+
+export interface SubscriptionAddOnCreate {
+  /**
+   * If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be used. If `add_on_source` is set to `item`, then the `code` from the associated item should be used. 
+   */
+  code?: string | null;
+  /**
+   * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add_on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
+   */
+  addOnSource?: string | null;
+  /**
+   * Quantity
+   */
+  quantity?: number | null;
+  /**
+   * * Optionally, override the add-on's default unit amount. * If the plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `unit_amount` must be absent. 
+   */
+  unitAmount?: number | null;
+  /**
+   * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+   */
+  tiers?: SubscriptionAddOnTier[] | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+
+}
+
+export interface SubscriptionAddOnTier {
+  /**
+   * Ending quantity
+   */
+  endingQuantity?: number | null;
+  /**
+   * Unit amount
+   */
+  unitAmount?: number | null;
+
+}
+
+export interface SubscriptionUpdate {
+  /**
+   * Change collection method
+   */
+  collectionMethod?: string | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+  /**
+   * The remaining billing cycles in the current term.
+   */
+  remainingBillingCycles?: number | null;
+  /**
+   * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
+   */
+  renewalBillingCycles?: number | null;
+  /**
+   * Whether the subscription renews at the end of its term.
+   */
+  autoRenew?: boolean | null;
+  /**
+   * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. For a subscription in a trial period, this will change when the trial expires. This parameter is useful for postponement of a subscription to change its billing date without proration.
+   */
+  nextBillDate?: Date | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
+   */
+  termsAndConditions?: string | null;
+  /**
+   * Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.
+   */
+  customerNotes?: string | null;
+  /**
+   * For manual invoicing, this identifies the PO number associated with the subscription.
+   */
+  poNumber?: string | null;
+  /**
+   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   */
+  netTerms?: number | null;
+  /**
+   * Subscription shipping details
+   */
+  shipping?: SubscriptionShippingUpdate | null;
+
+}
+
+export interface SubscriptionShippingUpdate {
+  /**
+   * Object type
+   */
+  object?: string | null;
+  address?: ShippingAddressCreate | null;
+  /**
+   * Assign a shipping address from the account's existing shipping addresses.
+   */
+  addressId?: string | null;
+
+}
+
+export interface SubscriptionCancel {
+  /**
+   * The timeframe parameter controls when the expiration takes place. The `bill_date` timeframe causes the subscription to expire when the subscription is scheduled to bill next. The `term_end` timeframe causes the subscription to continue to bill until the end of the subscription term, then expire.
+   */
+  timeframe?: string | null;
+
+}
+
+export interface SubscriptionPause {
+  /**
+   * Number of billing cycles to pause the subscriptions.
+   */
+  remainingPauseCycles?: number | null;
+
+}
+
+export interface SubscriptionChangeCreate {
+  /**
+   * The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription term ends. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe option is accepted as an alias for `term_end`.
+   */
+  timeframe?: string | null;
+  /**
+   * If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.
+   */
+  planId?: string | null;
+  /**
+   * If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.
+   */
+  planCode?: string | null;
+  /**
+   * Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.
+   */
+  unitAmount?: number | null;
+  /**
+   * Optionally override the default quantity of 1.
+   */
+  quantity?: number | null;
+  /**
+   * The shipping address can currently only be changed immediately, using SubscriptionUpdate.
+   */
+  shipping?: SubscriptionChangeShippingCreate | null;
+  /**
+   * A list of coupon_codes to be redeemed on the subscription during the change. Only allowed if timeframe is now and you change something about the subscription that creates an invoice.
+   */
+  couponCodes?: string[] | null;
+  /**
+   * If you provide a value for this field it will replace any existing add-ons. So, when adding or modifying an add-on, you need to include the existing subscription add-ons. Unchanged add-ons can be included just using the subscription add-on's ID: `{"id": "abc123"}`.  If a subscription add-on's `code` is supplied without the `id`, `{"code": "def456"}`, the subscription add-on attributes will be set to the current values of the plan add-on unless provided in the request.  - If an `id` is passed, any attributes not passed in will pull from the   existing subscription add-on - If a `code` is passed, any attributes not passed in will pull from the   current values of the plan add-on - Attributes passed in as part of the request will override either of the   above scenarios 
+   */
+  addOns?: SubscriptionAddOnUpdate[] | null;
+  /**
+   * Collection method
+   */
+  collectionMethod?: string | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+  /**
+   * For manual invoicing, this identifies the PO number associated with the subscription.
+   */
+  poNumber?: string | null;
+  /**
+   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   */
+  netTerms?: number | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+
+}
+
+export interface SubscriptionChangeShippingCreate {
+  /**
+   * The id of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodId?: string | null;
+  /**
+   * The code of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodCode?: string | null;
+  /**
+   * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
+   */
+  amount?: number | null;
+
+}
+
+export interface SubscriptionAddOnUpdate {
+  /**
+   * When an id is provided, the existing subscription add-on attributes will persist unless overridden in the request. 
+   */
+  id?: string | null;
+  /**
+   * If a code is provided without an id, the subscription add-on attributes will be set to the current value for those attributes on the plan add-on unless provided in the request. If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be used. If `add_on_source` is set to `item`, then the `code` from the associated item should be used. 
+   */
+  code?: string | null;
+  /**
+   * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add_on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
+   */
+  addOnSource?: string | null;
+  /**
+   * Quantity
+   */
+  quantity?: number | null;
+  /**
+   * Optionally, override the add-on's default unit amount.
+   */
+  unitAmount?: number | null;
+  /**
+   * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+   */
+  tiers?: SubscriptionAddOnTier[] | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+
+}
+
+export interface PurchaseCreate {
+  /**
+   * 3-letter ISO 4217 currency code.
+   */
+  currency?: string | null;
+  account?: AccountPurchase | null;
+  /**
+   * Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.
+   */
+  collectionMethod?: string | null;
+  /**
+   * For manual invoicing, this identifies the PO number associated with the subscription.
+   */
+  poNumber?: string | null;
+  /**
+   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   */
+  netTerms?: number | null;
+  /**
+   * Terms and conditions to be put on the purchase invoice.
+   */
+  termsAndConditions?: string | null;
+  /**
+   * Customer notes
+   */
+  customerNotes?: string | null;
+  /**
+   * VAT reverse charge notes for cross border European tax settlement.
+   */
+  vatReverseChargeNotes?: string | null;
+  /**
+   * Notes to be put on the credit invoice resulting from credits in the purchase, if any.
+   */
+  creditCustomerNotes?: string | null;
+  /**
+   * The default payment gateway identifier to be used for the purchase transaction.  This will also be applied as the default for any subscriptions included in the purchase request.
+   */
+  gatewayCode?: string | null;
+  shipping?: ShippingPurchase | null;
+  /**
+   * A list of one time charges or credits to be created with the purchase.
+   */
+  lineItems?: LineItemCreate[] | null;
+  /**
+   * A list of subscriptions to be created with the purchase.
+   */
+  subscriptions?: SubscriptionPurchase[] | null;
+  /**
+   * A list of coupon_codes to be redeemed on the subscription or account during the purchase.
+   */
+  couponCodes?: string[] | null;
+  /**
+   * A gift card redemption code to be redeemed on the purchase invoice.
+   */
+  giftCardRedemptionCode?: string | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+
+}
+
+export interface AccountPurchase {
+  /**
+   * Optional, but if present allows an existing account to be used and updated as part of the purchase.
+   */
+  id?: string | null;
+  /**
+   * The unique identifier of the account. This cannot be changed once the account is created.
+   */
+  code?: string | null;
+  acquisition?: AccountAcquisitionUpdatable | null;
+  /**
+   * A secondary value for the account.
+   */
+  username?: string | null;
+  /**
+   * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
+   */
+  email?: string | null;
+  /**
+   * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
+   */
+  preferredLocale?: string | null;
+  /**
+   * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
+   */
+  ccEmails?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  company?: string | null;
+  /**
+   * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
+   */
+  vatNumber?: string | null;
+  /**
+   * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
+   */
+  taxExempt?: boolean | null;
+  /**
+   * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
+   */
+  exemptionCertificate?: string | null;
+  /**
+   * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+   */
+  parentAccountCode?: string | null;
+  /**
+   * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+   */
+  parentAccountId?: string | null;
+  /**
+   * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
+   */
+  billTo?: string | null;
+  /**
+   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+   */
+  transactionType?: string | null;
+  address?: Address | null;
+  billingInfo?: BillingInfoCreate | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+
+}
+
+export interface ShippingPurchase {
+  /**
+   * Assign a shipping address from the account's existing shipping addresses. If this and `shipping_address` are both present, `shipping_address` will take precedence.
+   */
+  addressId?: string | null;
+  address?: ShippingAddressCreate | null;
+  /**
+   * A list of shipping fees to be created as charges with the purchase.
+   */
+  fees?: ShippingFeeCreate[] | null;
+
+}
+
+export interface ShippingFeeCreate {
+  /**
+   * The id of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodId?: string | null;
+  /**
+   * The code of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodCode?: string | null;
+  /**
+   * This is priced in the purchase's currency.
+   */
+  amount?: number | null;
+
+}
+
+export interface SubscriptionPurchase {
+  /**
+   * Plan code
+   */
+  planCode?: string | null;
+  /**
+   * Plan ID
+   */
+  planId?: string | null;
+  /**
+   * Override the unit amount of the subscription plan by setting this value in cents. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
+   */
+  unitAmount?: number | null;
+  /**
+   * Optionally override the default quantity of 1.
+   */
+  quantity?: number | null;
+  /**
+   * Add-ons
+   */
+  addOns?: SubscriptionAddOnCreate[] | null;
+  /**
+   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+   */
+  customFields?: CustomField[] | null;
+  /**
+   * Create a shipping address on the account and assign it to the subscription.
+   */
+  shipping?: SubscriptionShippingPurchase | null;
+  /**
+   * If set, overrides the default trial behavior for the subscription. The date must be in the future.
+   */
+  trialEndsAt?: Date | null;
+  /**
+   * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.
+   */
+  nextBillDate?: Date | null;
+  /**
+   * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
+   */
+  totalBillingCycles?: number | null;
+  /**
+   * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
+   */
+  renewalBillingCycles?: number | null;
+  /**
+   * Whether the subscription renews at the end of its term.
+   */
+  autoRenew?: boolean | null;
+  /**
+   * Revenue schedule type
+   */
+  revenueScheduleType?: string | null;
+
+}
+
+export interface SubscriptionShippingPurchase {
+  /**
+   * The id of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodId?: string | null;
+  /**
+   * The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+   */
+  methodCode?: string | null;
+  /**
+   * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
+   */
+  amount?: number | null;
+
+}
+
 
 export declare class Client {
   constructor(apiKey: string);
@@ -2562,7 +4385,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountCreate}
    * @return {Promise<Account>} An account.
    */
-  createAccount(body: object): Promise<Account>;
+  createAccount(body: AccountCreate): Promise<Account>;
   /**
    * Fetch an account
    *
@@ -2617,7 +4440,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountUpdate}
    * @return {Promise<Account>} An account.
    */
-  updateAccount(accountId: string, body: object): Promise<Account>;
+  updateAccount(accountId: string, body: AccountUpdate): Promise<Account>;
   /**
    * Deactivate an account
    *
@@ -2697,7 +4520,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountAcquisitionUpdatable}
    * @return {Promise<AccountAcquisition>} An account's updated acquisition data.
    */
-  updateAccountAcquisition(accountId: string, body: object): Promise<AccountAcquisition>;
+  updateAccountAcquisition(accountId: string, body: AccountAcquisitionUpdatable): Promise<AccountAcquisition>;
   /**
    * Remove an account's acquisition data
    *
@@ -2826,7 +4649,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
    * @return {Promise<BillingInfo>} Updated billing information.
    */
-  updateBillingInfo(accountId: string, body: object): Promise<BillingInfo>;
+  updateBillingInfo(accountId: string, body: BillingInfoCreate): Promise<BillingInfo>;
   /**
    * Remove an account's billing information
    *
@@ -2926,7 +4749,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponRedemptionCreate}
    * @return {Promise<CouponRedemption>} Returns the new coupon redemption.
    */
-  createCouponRedemption(accountId: string, body: object): Promise<CouponRedemption>;
+  createCouponRedemption(accountId: string, body: CouponRedemptionCreate): Promise<CouponRedemption>;
   /**
    * Delete the active coupon redemption from an account
    *
@@ -3059,7 +4882,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices.
    */
-  createInvoice(accountId: string, body: object): Promise<InvoiceCollection>;
+  createInvoice(accountId: string, body: InvoiceCreate): Promise<InvoiceCollection>;
   /**
    * Preview new invoice for pending line items
    *
@@ -3091,7 +4914,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the invoice previews.
    */
-  previewInvoice(accountId: string, body: object): Promise<InvoiceCollection>;
+  previewInvoice(accountId: string, body: InvoiceCreate): Promise<InvoiceCollection>;
   /**
    * List an account's line items
    *
@@ -3166,7 +4989,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {LineItemCreate}
    * @return {Promise<LineItem>} Returns the new line item.
    */
-  createLineItem(accountId: string, body: object): Promise<LineItem>;
+  createLineItem(accountId: string, body: LineItemCreate): Promise<LineItem>;
   /**
    * Fetch a list of an account's notes
    *
@@ -3298,7 +5121,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressCreate}
    * @return {Promise<ShippingAddress>} Returns the new shipping address.
    */
-  createShippingAddress(accountId: string, body: object): Promise<ShippingAddress>;
+  createShippingAddress(accountId: string, body: ShippingAddressCreate): Promise<ShippingAddress>;
   /**
    * Fetch an account's shipping address
    *
@@ -3355,7 +5178,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressUpdate}
    * @return {Promise<ShippingAddress>} The updated shipping address.
    */
-  updateShippingAddress(accountId: string, shippingAddressId: string, body: object): Promise<ShippingAddress>;
+  updateShippingAddress(accountId: string, shippingAddressId: string, body: ShippingAddressUpdate): Promise<ShippingAddress>;
   /**
    * Remove an account's shipping address
    *
@@ -3622,7 +5445,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponCreate}
    * @return {Promise<Coupon>} A new coupon.
    */
-  createCoupon(body: object): Promise<Coupon>;
+  createCoupon(body: CouponCreate): Promise<Coupon>;
   /**
    * Fetch a coupon
    *
@@ -3676,7 +5499,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
    * @return {Promise<Coupon>} The updated coupon.
    */
-  updateCoupon(couponId: string, body: object): Promise<Coupon>;
+  updateCoupon(couponId: string, body: CouponUpdate): Promise<Coupon>;
   /**
    * Expire a coupon
    *
@@ -3918,7 +5741,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemCreate}
    * @return {Promise<Item>} A new item.
    */
-  createItem(body: object): Promise<Item>;
+  createItem(body: ItemCreate): Promise<Item>;
   /**
    * Fetch an item
    *
@@ -3973,7 +5796,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemUpdate}
    * @return {Promise<Item>} The updated item.
    */
-  updateItem(itemId: string, body: object): Promise<Item>;
+  updateItem(itemId: string, body: ItemUpdate): Promise<Item>;
   /**
    * Deactivate an item
    *
@@ -4124,7 +5947,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceUpdatable}
    * @return {Promise<Invoice>} An invoice.
    */
-  putInvoice(invoiceId: string, body: object): Promise<Invoice>;
+  putInvoice(invoiceId: string, body: InvoiceUpdatable): Promise<Invoice>;
   /**
    * Fetch an invoice as a PDF
    *
@@ -4316,7 +6139,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ExternalTransaction}
    * @return {Promise<Transaction>} The recorded transaction.
    */
-  recordExternalTransaction(invoiceId: string, body: object): Promise<Transaction>;
+  recordExternalTransaction(invoiceId: string, body: ExternalTransaction): Promise<Transaction>;
   /**
    * List an invoice's line items
    *
@@ -4448,7 +6271,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceRefund}
    * @return {Promise<Invoice>} Returns the new credit invoice.
    */
-  refundInvoice(invoiceId: string, body: object): Promise<Invoice>;
+  refundInvoice(invoiceId: string, body: InvoiceRefund): Promise<Invoice>;
   /**
    * List a site's line items
    *
@@ -4617,7 +6440,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanCreate}
    * @return {Promise<Plan>} A plan.
    */
-  createPlan(body: object): Promise<Plan>;
+  createPlan(body: PlanCreate): Promise<Plan>;
   /**
    * Fetch a plan
    *
@@ -4671,7 +6494,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanUpdate}
    * @return {Promise<Plan>} A plan.
    */
-  updatePlan(planId: string, body: object): Promise<Plan>;
+  updatePlan(planId: string, body: PlanUpdate): Promise<Plan>;
   /**
    * Remove a plan
    *
@@ -4776,7 +6599,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnCreate}
    * @return {Promise<AddOn>} An add-on.
    */
-  createPlanAddOn(planId: string, body: object): Promise<AddOn>;
+  createPlanAddOn(planId: string, body: AddOnCreate): Promise<AddOn>;
   /**
    * Fetch a plan's add-on
    *
@@ -4832,7 +6655,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnUpdate}
    * @return {Promise<AddOn>} An add-on.
    */
-  updatePlanAddOn(planId: string, addOnId: string, body: object): Promise<AddOn>;
+  updatePlanAddOn(planId: string, addOnId: string, body: AddOnUpdate): Promise<AddOn>;
   /**
    * Remove an add-on
    *
@@ -4974,7 +6797,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodCreate}
    * @return {Promise<ShippingMethod>} A new shipping method.
    */
-  createShippingMethod(body: object): Promise<ShippingMethod>;
+  createShippingMethod(body: ShippingMethodCreate): Promise<ShippingMethod>;
   /**
    * Fetch a shipping method
    *
@@ -4995,7 +6818,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodUpdate}
    * @return {Promise<ShippingMethod>} The updated shipping method.
    */
-  updateShippingMethod(shippingMethodId: string, body: object): Promise<ShippingMethod>;
+  updateShippingMethod(shippingMethodId: string, body: ShippingMethodUpdate): Promise<ShippingMethod>;
   /**
    * Deactivate a shipping method
    *
@@ -5083,7 +6906,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCreate}
    * @return {Promise<Subscription>} A subscription.
    */
-  createSubscription(body: object): Promise<Subscription>;
+  createSubscription(body: SubscriptionCreate): Promise<Subscription>;
   /**
    * Fetch a subscription
    *
@@ -5139,7 +6962,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionUpdate}
    * @return {Promise<Subscription>} A subscription.
    */
-  modifySubscription(subscriptionId: string, body: object): Promise<Subscription>;
+  modifySubscription(subscriptionId: string, body: SubscriptionUpdate): Promise<Subscription>;
   /**
    * Terminate a subscription
    *
@@ -5257,7 +7080,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionPause}
    * @return {Promise<Subscription>} A subscription.
    */
-  pauseSubscription(subscriptionId: string, body: object): Promise<Subscription>;
+  pauseSubscription(subscriptionId: string, body: SubscriptionPause): Promise<Subscription>;
   /**
    * Resume subscription
    *
@@ -5348,7 +7171,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChange>} A subscription change.
    */
-  createSubscriptionChange(subscriptionId: string, body: object): Promise<SubscriptionChange>;
+  createSubscriptionChange(subscriptionId: string, body: SubscriptionChangeCreate): Promise<SubscriptionChange>;
   /**
    * Delete the pending subscription change
    *
@@ -5384,7 +7207,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChangePreview>} A subscription change.
    */
-  previewSubscriptionChange(subscriptionId: string, body: object): Promise<SubscriptionChangePreview>;
+  previewSubscriptionChange(subscriptionId: string, body: SubscriptionChangeCreate): Promise<SubscriptionChangePreview>;
   /**
    * List a subscription's invoices
    *
@@ -5651,7 +7474,7 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices
    */
-  createPurchase(body: object): Promise<InvoiceCollection>;
+  createPurchase(body: PurchaseCreate): Promise<InvoiceCollection>;
   /**
    * Preview a new purchase
    *
@@ -5691,6 +7514,6 @@ export declare class Client {
    * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns preview of the new invoices
    */
-  previewPurchase(body: object): Promise<InvoiceCollection>;
+  previewPurchase(body: PurchaseCreate): Promise<InvoiceCollection>;
 
 }


### PR DESCRIPTION
Previously, the `body` parameter of the operations was just defined as a plain `object`. This uses their proper Request types as we do in the other statically typed clients. We're not considering this a breaking change because if you had passed an invalid object before, the server would already be stopping you. We are to other interpretations from our typescript users.

Example use:

```js

import * as recurly from "recurly";

const client = new recurly.Client('<apikey>')

async function runIt() {

  const acctReq: recurly.AccountCreate = {
    code: 'test12345678',
    firstName: 'Benjamin',
    lastName: 'Du Monde'
  }
  let account = await client.createAccount(acctReq)
  console.log(account)
  account = await client.getAccount(account.id)
  console.log(account)
  // plain objects still work as long as they conform to schema
  const updates = {
    firstName: 'Bill',
    lastName: 'Cauchois'
  }
  account = await client.updateAccount(account.id, updates)
  console.log(account)
  account = await client.deactivateAccount(account.id)
  console.log(account)
}

runIt()
```
