### PR TITLE
Update Pager to accept query parameters as options.params

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1099,7 +1099,7 @@ export interface Invoice {
    * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.
    */
   customerNotes: string | null;
-  lineItems: LineItem | null;
+  lineItems: LineItemList | null;
   /**
    * Transactions
    */

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -79,9 +79,7 @@ class BaseClient {
 
   _makeRequest (method, path, body, options = {}) {
     this._validateOptions(options)
-    if (options.params && Object.keys(options.params).length > 0) {
-      path = path + '?' + querystring.stringify(casters.castRequest(options.params))
-    }
+    path = this._buildPath(path, options)
 
     const reqOptions = this._getDefaultOptions(method, path)
 
@@ -116,6 +114,25 @@ class BaseClient {
         })
         .catch(reject)
     })
+  }
+
+  // Converts array parameters to CSV strings to maintain consistency with
+  // how the server expects the request to be formatted while providing the
+  // developer with an array type to maintain developer happiness!
+  _buildPath (path, options = {}) {
+    if (!options.params || Object.keys(options.params).length === 0) {
+      return path
+    }
+    const converted = Object.keys(options.params).reduce((res, key) => {
+      if (Array.isArray(options.params[key])) {
+        res[key] = options.params[key].join(',')
+      } else {
+        res[key] = options.params[key]
+      }
+      return res
+    }, {})
+
+    return path + '?' + querystring.stringify(casters.castRequest(converted))
   }
 
   _getDefaultOptions (method, path) {

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -79,9 +79,9 @@ class BaseClient {
 
   _makeRequest (method, path, body, options = {}) {
     this._validateOptions(options)
-    path = this._buildPath(path, options)
+    const pathAndQuery = path + this._buildQuery(options)
 
-    const reqOptions = this._getDefaultOptions(method, path)
+    const reqOptions = this._getDefaultOptions(method, pathAndQuery)
 
     return new Promise((resolve, reject) => {
       const httpReq = this._requestAdapter(reqOptions, body)
@@ -116,13 +116,11 @@ class BaseClient {
     })
   }
 
-  // Converts array parameters to CSV strings to maintain consistency with
-  // how the server expects the request to be formatted while providing the
-  // developer with an array type to maintain developer happiness!
-  _buildPath (path, options = {}) {
+  _buildQuery (options = {}) {
     if (!options.params || Object.keys(options.params).length === 0) {
-      return path
+      return ''
     }
+    // The server expects array parameters as CSV strings
     const converted = Object.keys(options.params).reduce((res, key) => {
       if (Array.isArray(options.params[key])) {
         res[key] = options.params[key].join(',')
@@ -132,7 +130,7 @@ class BaseClient {
       return res
     }, {})
 
-    return path + '?' + querystring.stringify(casters.castRequest(converted))
+    return '?' + querystring.stringify(casters.castRequest(converted))
   }
 
   _getDefaultOptions (method, path) {

--- a/lib/recurly/Pager.js
+++ b/lib/recurly/Pager.js
@@ -4,13 +4,13 @@
  *
  * @param {Client} client
  * @param {string} path
- * @param {Object} params
+ * @param {Object} options
  */
 class Pager {
-  constructor (client, path, params) {
+  constructor (client, path, options) {
     this.client = client
     this.path = path
-    this.params = this._mapArrayParams(params)
+    this.options = options
   }
 
   /**
@@ -37,7 +37,7 @@ class Pager {
    * @return {Number} The count of resources
    */
   async count () {
-    const empty = await this.client._makeRequest('HEAD', this.path, null, { params: this.params })
+    const empty = await this.client._makeRequest('HEAD', this.path, null, this.options)
     return empty.getResponse().recordCount
   }
 
@@ -49,8 +49,10 @@ class Pager {
    * @return {Object} The first resource in the list
    */
   async first () {
-    const firstParams = Object.assign({}, this.params, { limit: 1 })
-    let results = await this.client._makeRequest('GET', this.path, null, { params: firstParams })
+    const firstOptions = Object.assign({}, this.options, {
+      params: Object.assign({}, this.options.params, { limit: 1 })
+    })
+    let results = await this.client._makeRequest('GET', this.path, null, firstOptions)
     return results.data && results.data[0]
   }
 
@@ -61,7 +63,10 @@ class Pager {
           return Promise.resolve({ done: true })
         }
         return new Promise((resolve, reject) => {
-          this.client._makeRequest('GET', this.path, null, { params: this._consumeParams() })
+          const pageOptions = Object.assign({}, this.options, {
+            params: this._consumeParams()
+          })
+          this.client._makeRequest('GET', this.path, null, pageOptions)
             .then(results => {
               this.done = !results.hasMore
               this.path = results.next
@@ -120,21 +125,7 @@ class Pager {
       return null
     }
     this._paramsConsumed = true
-    return this.params
-  }
-
-  // Converts array parameters to CSV strings to maintain consistency with
-  // how the server expects the request to be formatted while providing the
-  // developer with an array type to maintain developer happiness!
-  _mapArrayParams (params) {
-    return Object.keys(params).reduce((res, key) => {
-      if (Array.isArray(params[key])) {
-        res[key] = params[key].join(',')
-      } else {
-        res[key] = params[key]
-      }
-      return res
-    }, {})
+    return this.options.params
   }
 }
 

--- a/lib/recurly/resources/Invoice.js
+++ b/lib/recurly/resources/Invoice.js
@@ -24,7 +24,7 @@ const Resource = require('../Resource')
  * @prop {number} discount - Total discounts applied to this invoice.
  * @prop {Date} dueAt - Date invoice is due. This is the date the net terms are reached.
  * @prop {string} id - Invoice ID
- * @prop {LineItem} lineItems
+ * @prop {LineItemList} lineItems
  * @prop {number} netTerms - Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
  * @prop {string} number - If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
  * @prop {string} object - Object type
@@ -62,7 +62,7 @@ class Invoice extends Resource {
       discount: Number,
       dueAt: Date,
       id: String,
-      lineItems: 'LineItem',
+      lineItems: 'LineItemList',
       netTerms: Number,
       number: String,
       object: String,

--- a/test/mock_client.js
+++ b/test/mock_client.js
@@ -13,10 +13,10 @@ class MockClient extends BaseClient {
     return 'v2022-01-01'
   }
 
-  listResources (params = {}) {
+  listResources (options = {}) {
     let path = '/resources'
     path = this._interpolatePath(path)
-    return new Pager(this, path, params)
+    return new Pager(this, path, options)
   }
 
   async getResource (resourceId) {

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -80,25 +80,17 @@ describe('BaseClient', () => {
     })
   })
 
-  describe('#_buildPath', () => {
-    it('Should return path when options has no params key', () => {
-      const path = '/resources/myid'
-      assert.equal(client._buildPath(path), path)
-    })
-
-    it('Should return path when options.params is an empty object', () => {
-      const path = '/resources/myid'
-      assert.equal(client._buildPath(path, { params: {} }), path)
+  describe('#_buildQuery', () => {
+    it('Should return an empty string when options.params is an empty object', () => {
+      assert.equal(client._buildQuery({ params: {} }), '')
     })
 
     it('Should add params to query string', () => {
-      const path = '/resources/myid'
-      assert.equal(client._buildPath(path, { params: { limit: 1 } }), `${path}?limit=1`)
+      assert.equal(client._buildQuery({ params: { limit: 1 } }), '?limit=1')
     })
 
     it('Should convert array params to csv', () => {
-      const path = '/resources/myid'
-      assert.equal(client._buildPath(path, { params: { ids: [ 1, 2 ] } }), `${path}?ids=1%2C2`)
+      assert.equal(client._buildQuery({ params: { ids: [ 1, 2 ] } }), '?ids=1%2C2')
     })
   })
 

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -80,6 +80,28 @@ describe('BaseClient', () => {
     })
   })
 
+  describe('#_buildPath', () => {
+    it('Should return path when options has no params key', () => {
+      const path = '/resources/myid'
+      assert.equal(client._buildPath(path), path)
+    })
+
+    it('Should return path when options.params is an empty object', () => {
+      const path = '/resources/myid'
+      assert.equal(client._buildPath(path, { params: {} }), path)
+    })
+
+    it('Should add params to query string', () => {
+      const path = '/resources/myid'
+      assert.equal(client._buildPath(path, { params: { limit: 1 } }), `${path}?limit=1`)
+    })
+
+    it('Should convert array params to csv', () => {
+      const path = '/resources/myid'
+      assert.equal(client._buildPath(path, { params: { ids: [ 1, 2 ] } }), `${path}?ids=1%2C2`)
+    })
+  })
+
   describe('with mocked request adapter', () => {
     beforeEach(() => {
       client.mock((resp, options) => {

--- a/test/recurly/Pager.test.js
+++ b/test/recurly/Pager.test.js
@@ -7,14 +7,14 @@ const MockClient = require('../mock_client')
 const Pager = require('../../lib/recurly/Pager')
 
 const client = new MockClient('myapikey')
-const pager = new Pager(client, '/resources', { limit: 200 })
+const pager = new Pager(client, '/resources', { params: { limit: 200 } })
 
 describe('Pager', () => {
   describe('#constructor', () => {
     it('Should set the internal state', () => {
       assert.equal(pager.client, client)
       assert.equal(pager.path, '/resources')
-      assert.deepEqual(pager.params, { limit: 200 })
+      assert.deepEqual(pager.options, { params: { limit: 200 } })
     })
   })
 
@@ -70,7 +70,7 @@ describe('Pager', () => {
     })
 
     it('Should return the count from recurly-total-records header', () => {
-      let p = client.listResources({ sort: 'updated_at' })
+      let p = client.listResources({ params: { sort: 'updated_at' } })
       return p.count().then(count => {
         assert.equal(count, 9000)
       })
@@ -115,7 +115,7 @@ describe('Pager', () => {
         assert(typeof pager.each === 'function')
       })
       it('Should page through each component', () => {
-        const resources = client.listResources({ state: 'active', limit: 3 })
+        const resources = client.listResources({ params: { state: 'active', limit: 3 } })
         let count = 0
 
         return (async () => {
@@ -134,7 +134,7 @@ describe('Pager', () => {
         assert(typeof pager.eachPage === 'function')
       })
       it('Should page through each page', () => {
-        const resources = client.listResources({ state: 'active', limit: 3 })
+        const resources = client.listResources({ params: { state: 'active', limit: 3 } })
         let count = 0
         let pageCount = 0
 


### PR DESCRIPTION
When using the 3.x client, all operations expect query parameters to be specified in the `options.params` object. The `Pager` class, however, incorrectly allowed query parameters to be specified directly on the `options` object. This creates confusion between the standard operations and the pager operations. Additionally, it introduces complications when attempting to allow other options to be specified for the request (headers for example).

This fixes the `Pager` class to be consistent with the other operations. Due to the fact that this is a breaking change, the enhancement will be published with the `4.x` client.

In the `3.x` client:
```node
const accounts = client.listAccounts({ limit: 200 })
```

In the `4.x` client:
```node
const accounts = client.listAccounts({ params: { limit: 200 } })
```