### PR TITLE
Release 3.12.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.11.0
+current_version = 3.12.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -9,4 +9,3 @@ serialize =
 [bumpversion:file:package.json]
 
 [bumpversion:file:doc/GETTING_STARTED.md]
-

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -15,7 +15,7 @@ Or manually insert the dependency into the `dependencies` section of your `packa
 ```
 {
   // ...
-  "recurly" : "^3.11.0"
+  "recurly" : "^3.12.0"
   // ...
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recurly",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Recurly V3 node client",
   "main": "lib/recurly.js",
   "types": "lib/recurly.d.ts",


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-node/compare/3.11.0...HEAD)

**Implemented enhancements:**

- Fri Aug 21 16:24:16 UTC 2020 Upgrade API version v2019-10-10 [\#141](https://github.com/recurly/recurly-client-node/pull/141) ([douglasmiller](https://github.com/douglasmiller))
- Fixes typo in ServiceUnavailableError [\#140](https://github.com/recurly/recurly-client-node/pull/140) ([chrissrogers](https://github.com/chrissrogers))