### PR TITLE
Makes response header references case insensitive

### DIFF
--- a/lib/recurly/Http.js
+++ b/lib/recurly/Http.js
@@ -30,8 +30,14 @@ function makeRequest (options, requestBody) {
 
     const submitRequest = () => {
       const httpRequest = https.request(options, (httpResponse) => {
+        // downcase response headers
+        const responseHeaders = {}
+        for (const header in httpResponse.headers) {
+          responseHeaders[header.toLowerCase()] = httpResponse.headers[header]
+        }
+
         var responseStream
-        const encoding = httpResponse.headers['content-encoding']
+        const encoding = responseHeaders['content-encoding']
 
         if (encoding === 'gzip') {
           responseStream = zlib.createGunzip(ZLIB_OPTIONS)
@@ -42,7 +48,7 @@ function makeRequest (options, requestBody) {
         } else {
           responseStream = httpResponse
         }
-        responseStream.setEncoding(responseEncoding(httpResponse.headers['content-type']))
+        responseStream.setEncoding(responseEncoding(responseHeaders['content-type']))
 
         const chunks = []
         responseStream.on('data', chunk => chunks.push(chunk))
@@ -107,30 +113,35 @@ class Response {
     if (body && body.length > 0) {
       resp.body = body
     }
+    // downcase response headers
+    const responseHeaders = {}
+    for (const header in response.headers) {
+      responseHeaders[header.toLowerCase()] = response.headers[header]
+    }
     resp.status = response.statusCode
-    resp.requestId = response.headers['x-request-id']
-    resp.rateLimit = parseInt(response.headers['x-ratelimit-limit'], 10)
-    resp.rateLimitRemaining = parseInt(response.headers['x-ratelimit-remaining'], 10)
-    resp.rateLimitReset = new Date(parseInt(response.headers['x-ratelimit-reset'], 10) * 1000)
-    if (response.headers['content-type']) {
-      resp.contentType = response.headers['content-type'].split(';')[0]
+    resp.requestId = responseHeaders['x-request-id']
+    resp.rateLimit = parseInt(responseHeaders['x-ratelimit-limit'], 10)
+    resp.rateLimitRemaining = parseInt(responseHeaders['x-ratelimit-remaining'], 10)
+    resp.rateLimitReset = new Date(parseInt(responseHeaders['x-ratelimit-reset'], 10) * 1000)
+    if (responseHeaders['content-type']) {
+      resp.contentType = responseHeaders['content-type'].split(';')[0]
     }
     resp.recordCount = null
     resp.apiDeprecated = false
     resp.apiSunsetDate = null
-    const deprecated = response.headers['Recurly-Deprecated'] || ''
+    const deprecated = responseHeaders['recurly-deprecated'] || ''
     if (deprecated.toUpperCase() === 'TRUE') {
       resp.apiDeprecated = true
-      resp.apiSunsetDate = response.headers['Recurly-Sunset-Date']
+      resp.apiSunsetDate = responseHeaders['recurly-sunset-date']
     }
 
-    if (response.headers['recurly-total-records']) {
-      resp.recordCount = parseInt(response.headers['recurly-total-records'], 10)
+    if (responseHeaders['recurly-total-records']) {
+      resp.recordCount = parseInt(responseHeaders['recurly-total-records'], 10)
     }
-    resp.date = response.headers['date']
+    resp.date = responseHeaders['date']
     resp.proxyMetadata = {
-      'server': response.headers['server'],
-      'cf-ray': response.headers['cf-ray']
+      'server': responseHeaders['server'],
+      'cf-ray': responseHeaders['cf-ray']
     }
 
     return resp


### PR DESCRIPTION
All response headers previously were being accessed through lowercase values with the exception of `Recurly-Sunset-Date` and `Recurly-Deprecated`

Pager/list methods are working fine with the current release. The update here is for the purpose of fixing the two above headers and future-proofing.