### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1,10 +1,10 @@
 // Type definitions for recurly
 // Project: recurly
-// Definitions by: Benjamin Eckel <dx@recurly.com>
+// Definitions by: Developer Experience <dx@recurly.com>
 
 export as namespace recurly;
 
-export interface Site {
+export declare class Site {
   /**
    * Site ID
    */
@@ -43,7 +43,7 @@ export interface Site {
 
 }
 
-export interface Address {
+export declare class Address {
   /**
    * First name
    */
@@ -83,7 +83,7 @@ export interface Address {
 
 }
 
-export interface Settings {
+export declare class Settings {
   /**
    * - full:      Full Address (Street, City, State, Postal Code and Country) - streetzip: Street and Postal Code only - zip:       Postal Code only - none:      No Address 
    */
@@ -96,7 +96,7 @@ export interface Settings {
 
 }
 
-export interface Error {
+export declare class Error {
   /**
    * Type
    */
@@ -112,7 +112,7 @@ export interface Error {
 
 }
 
-export interface Account {
+export declare class Account {
   id?: string | null;
   /**
    * Object type
@@ -218,7 +218,7 @@ export interface Account {
 
 }
 
-export interface ShippingAddress {
+export declare class ShippingAddress {
   /**
    * Shipping Address ID
    */
@@ -264,7 +264,7 @@ export interface ShippingAddress {
 
 }
 
-export interface BillingInfo {
+export declare class BillingInfo {
   id?: string | null;
   /**
    * Object type
@@ -301,7 +301,7 @@ export interface BillingInfo {
 
 }
 
-export interface PaymentMethod {
+export declare class PaymentMethod {
   object?: string | null;
   /**
    * Visa, MasterCard, American Express, Discover, JCB, etc.
@@ -358,7 +358,7 @@ export interface PaymentMethod {
 
 }
 
-export interface FraudInfo {
+export declare class FraudInfo {
   /**
    * Kount score
    */
@@ -374,7 +374,7 @@ export interface FraudInfo {
 
 }
 
-export interface BillingInfoUpdatedBy {
+export declare class BillingInfoUpdatedBy {
   /**
    * Customer's IP address when updating their billing information.
    */
@@ -386,7 +386,7 @@ export interface BillingInfoUpdatedBy {
 
 }
 
-export interface CustomField {
+export declare class CustomField {
   /**
    * Fields must be created in the UI before values can be assigned to them.
    */
@@ -398,7 +398,7 @@ export interface CustomField {
 
 }
 
-export interface ErrorMayHaveTransaction {
+export declare class ErrorMayHaveTransaction {
   /**
    * Type
    */
@@ -418,7 +418,7 @@ export interface ErrorMayHaveTransaction {
 
 }
 
-export interface TransactionError {
+export declare class TransactionError {
   /**
    * Object type
    */
@@ -450,7 +450,7 @@ export interface TransactionError {
 
 }
 
-export interface AccountAcquisition {
+export declare class AccountAcquisition {
   /**
    * Account balance
    */
@@ -487,7 +487,7 @@ export interface AccountAcquisition {
 
 }
 
-export interface AccountAcquisitionCost {
+export declare class AccountAcquisitionCost {
   /**
    * 3-letter ISO 4217 currency code.
    */
@@ -499,7 +499,7 @@ export interface AccountAcquisitionCost {
 
 }
 
-export interface AccountMini {
+export declare class AccountMini {
   id?: string | null;
   /**
    * Object type
@@ -521,7 +521,7 @@ export interface AccountMini {
 
 }
 
-export interface AccountBalance {
+export declare class AccountBalance {
   /**
    * Object type
    */
@@ -535,7 +535,7 @@ export interface AccountBalance {
 
 }
 
-export interface AccountBalanceAmount {
+export declare class AccountBalanceAmount {
   /**
    * 3-letter ISO 4217 currency code.
    */
@@ -547,7 +547,7 @@ export interface AccountBalanceAmount {
 
 }
 
-export interface CouponRedemption {
+export declare class CouponRedemption {
   /**
    * Coupon Redemption ID
    */
@@ -588,7 +588,7 @@ export interface CouponRedemption {
 
 }
 
-export interface Coupon {
+export declare class Coupon {
   /**
    * Coupon ID
    */
@@ -720,7 +720,7 @@ export interface Coupon {
 
 }
 
-export interface PlanMini {
+export declare class PlanMini {
   /**
    * Plan ID
    */
@@ -740,7 +740,7 @@ export interface PlanMini {
 
 }
 
-export interface ItemMini {
+export declare class ItemMini {
   /**
    * Item ID
    */
@@ -768,7 +768,7 @@ export interface ItemMini {
 
 }
 
-export interface CouponDiscount {
+export declare class CouponDiscount {
   type?: string | null;
   /**
    * This is only present when `type=percent`.
@@ -785,7 +785,7 @@ export interface CouponDiscount {
 
 }
 
-export interface CouponDiscountPricing {
+export declare class CouponDiscountPricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
@@ -797,7 +797,7 @@ export interface CouponDiscountPricing {
 
 }
 
-export interface CouponDiscountTrial {
+export declare class CouponDiscountTrial {
   /**
    * Temporal unit of the free trial
    */
@@ -809,7 +809,7 @@ export interface CouponDiscountTrial {
 
 }
 
-export interface CreditPayment {
+export declare class CreditPayment {
   /**
    * Credit Payment ID
    */
@@ -866,7 +866,7 @@ export interface CreditPayment {
 
 }
 
-export interface InvoiceMini {
+export declare class InvoiceMini {
   /**
    * Invoice ID
    */
@@ -890,7 +890,7 @@ export interface InvoiceMini {
 
 }
 
-export interface Transaction {
+export declare class Transaction {
   /**
    * Transaction ID
    */
@@ -1033,7 +1033,7 @@ export interface Transaction {
 
 }
 
-export interface TransactionPaymentGateway {
+export declare class TransactionPaymentGateway {
   id?: string | null;
   /**
    * Object type
@@ -1044,7 +1044,7 @@ export interface TransactionPaymentGateway {
 
 }
 
-export interface Invoice {
+export declare class Invoice {
   /**
    * Invoice ID
    */
@@ -1179,7 +1179,7 @@ export interface Invoice {
 
 }
 
-export interface InvoiceAddress {
+export declare class InvoiceAddress {
   /**
    * Name on account
    */
@@ -1227,7 +1227,7 @@ export interface InvoiceAddress {
 
 }
 
-export interface TaxInfo {
+export declare class TaxInfo {
   /**
    * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
    */
@@ -1243,7 +1243,7 @@ export interface TaxInfo {
 
 }
 
-export interface LineItemList {
+export declare class LineItemList {
   /**
    * Will always be List.
    */
@@ -1260,7 +1260,7 @@ export interface LineItemList {
 
 }
 
-export interface LineItem {
+export declare class LineItem {
   /**
    * Line item ID
    */
@@ -1449,7 +1449,7 @@ export interface LineItem {
 
 }
 
-export interface InvoiceCollection {
+export declare class InvoiceCollection {
   /**
    * Object type
    */
@@ -1462,7 +1462,7 @@ export interface InvoiceCollection {
 
 }
 
-export interface AccountNote {
+export declare class AccountNote {
   id?: string | null;
   /**
    * Object type
@@ -1475,7 +1475,7 @@ export interface AccountNote {
 
 }
 
-export interface User {
+export declare class User {
   id?: string | null;
   /**
    * Object type
@@ -1490,7 +1490,7 @@ export interface User {
 
 }
 
-export interface Subscription {
+export declare class Subscription {
   /**
    * Subscription ID
    */
@@ -1520,7 +1520,7 @@ export interface Subscription {
    */
   shipping?: SubscriptionShipping | null;
   /**
-   * Coupon redemptions
+   * Returns subscription level coupon redemptions that are tied to this subscription.
    */
   couponRedemptions?: CouponRedemptionMini[] | null;
   /**
@@ -1662,7 +1662,7 @@ export interface Subscription {
 
 }
 
-export interface SubscriptionShipping {
+export declare class SubscriptionShipping {
   /**
    * Object type
    */
@@ -1676,7 +1676,7 @@ export interface SubscriptionShipping {
 
 }
 
-export interface ShippingMethodMini {
+export declare class ShippingMethodMini {
   /**
    * Shipping Method ID
    */
@@ -1696,7 +1696,7 @@ export interface ShippingMethodMini {
 
 }
 
-export interface CouponRedemptionMini {
+export declare class CouponRedemptionMini {
   /**
    * Coupon Redemption ID
    */
@@ -1721,7 +1721,7 @@ export interface CouponRedemptionMini {
 
 }
 
-export interface CouponMini {
+export declare class CouponMini {
   /**
    * Coupon ID
    */
@@ -1757,7 +1757,7 @@ export interface CouponMini {
 
 }
 
-export interface SubscriptionChange {
+export declare class SubscriptionChange {
   /**
    * The ID of the Subscription Change.
    */
@@ -1829,7 +1829,7 @@ export interface SubscriptionChange {
 
 }
 
-export interface SubscriptionAddOn {
+export declare class SubscriptionAddOn {
   /**
    * Subscription Add-on ID
    */
@@ -1889,7 +1889,7 @@ export interface SubscriptionAddOn {
 
 }
 
-export interface AddOnMini {
+export declare class AddOnMini {
   /**
    * Add-on ID
    */
@@ -1937,7 +1937,7 @@ export interface AddOnMini {
 
 }
 
-export interface SubscriptionAddOnTier {
+export declare class SubscriptionAddOnTier {
   /**
    * Ending quantity
    */
@@ -1949,7 +1949,7 @@ export interface SubscriptionAddOnTier {
 
 }
 
-export interface UniqueCouponCode {
+export declare class UniqueCouponCode {
   /**
    * Unique Coupon Code ID
    */
@@ -1993,7 +1993,7 @@ export interface UniqueCouponCode {
 
 }
 
-export interface CustomFieldDefinition {
+export declare class CustomFieldDefinition {
   /**
    * Custom field definition ID
    */
@@ -2037,7 +2037,7 @@ export interface CustomFieldDefinition {
 
 }
 
-export interface Item {
+export declare class Item {
   /**
    * Item ID
    */
@@ -2113,7 +2113,7 @@ export interface Item {
 
 }
 
-export interface Pricing {
+export declare class Pricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
@@ -2125,7 +2125,7 @@ export interface Pricing {
 
 }
 
-export interface MeasuredUnit {
+export declare class MeasuredUnit {
   /**
    * Item ID
    */
@@ -2165,12 +2165,12 @@ export interface MeasuredUnit {
 
 }
 
-export interface BinaryFile {
+export declare class BinaryFile {
   data?: string | null;
 
 }
 
-export interface Plan {
+export declare class Plan {
   /**
    * Plan ID
    */
@@ -2282,7 +2282,7 @@ export interface Plan {
 
 }
 
-export interface PlanPricing {
+export declare class PlanPricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
@@ -2298,7 +2298,7 @@ export interface PlanPricing {
 
 }
 
-export interface PlanHostedPages {
+export declare class PlanHostedPages {
   /**
    * URL to redirect to after signup on the hosted payment pages.
    */
@@ -2318,7 +2318,7 @@ export interface PlanHostedPages {
 
 }
 
-export interface AddOn {
+export declare class AddOn {
   /**
    * Add-on ID
    */
@@ -2426,7 +2426,7 @@ export interface AddOn {
 
 }
 
-export interface AddOnPricing {
+export declare class AddOnPricing {
   /**
    * 3-letter ISO 4217 currency code.
    */
@@ -2438,7 +2438,7 @@ export interface AddOnPricing {
 
 }
 
-export interface Tier {
+export declare class Tier {
   /**
    * Ending quantity
    */
@@ -2450,7 +2450,7 @@ export interface Tier {
 
 }
 
-export interface ShippingMethod {
+export declare class ShippingMethod {
   /**
    * Shipping Method ID
    */
@@ -2490,7 +2490,7 @@ export interface ShippingMethod {
 
 }
 
-export interface SubscriptionChangePreview {
+export declare class SubscriptionChangePreview {
   /**
    * The ID of the Subscription Change.
    */
@@ -2562,7 +2562,7 @@ export interface SubscriptionChangePreview {
 
 }
 
-export interface Usage {
+export declare class Usage {
   id?: string | null;
   /**
    * Object type
@@ -2623,7 +2623,7 @@ export interface Usage {
 
 }
 
-export interface ExportDates {
+export declare class ExportDates {
   /**
    * Object type
    */
@@ -2635,7 +2635,7 @@ export interface ExportDates {
 
 }
 
-export interface ExportFiles {
+export declare class ExportFiles {
   /**
    * Object type
    */
@@ -2644,7 +2644,7 @@ export interface ExportFiles {
 
 }
 
-export interface ExportFile {
+export declare class ExportFile {
   /**
    * Name of the export file.
    */
@@ -2669,100 +2669,101 @@ export declare class Pager<T> {
   count(): number;
   first(): T;
   each(): AsyncIterable<T>;
-  eachPage(): AsyncIterable<T>;
+  eachPage(): AsyncIterable<T[]>;
 }
+
 
 export interface AccountCreate {
   /**
-   * The unique identifier of the account. This cannot be changed once the account is created.
-   */
+    * The unique identifier of the account. This cannot be changed once the account is created.
+    */
   code?: string | null;
   acquisition?: AccountAcquisitionUpdatable | null;
   shippingAddresses?: ShippingAddressCreate[] | null;
   /**
-   * A secondary value for the account.
-   */
+    * A secondary value for the account.
+    */
   username?: string | null;
   /**
-   * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
-   */
+    * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
+    */
   email?: string | null;
   /**
-   * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
-   */
+    * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
+    */
   preferredLocale?: string | null;
   /**
-   * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
-   */
+    * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
+    */
   ccEmails?: string | null;
   firstName?: string | null;
   lastName?: string | null;
   company?: string | null;
   /**
-   * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
-   */
+    * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
+    */
   vatNumber?: string | null;
   /**
-   * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
-   */
+    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
+    */
   taxExempt?: boolean | null;
   /**
-   * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
-   */
+    * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
+    */
   exemptionCertificate?: string | null;
   /**
-   * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
-   */
+    * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+    */
   parentAccountCode?: string | null;
   /**
-   * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
-   */
+    * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+    */
   parentAccountId?: string | null;
   /**
-   * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
-   */
+    * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
+    */
   billTo?: string | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
   address?: Address | null;
   billingInfo?: BillingInfoCreate | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
 
 }
 
 export interface AccountAcquisitionUpdatable {
   /**
-   * Account balance
-   */
+    * Account balance
+    */
   cost?: AccountAcquisitionCost | null;
   /**
-   * The channel through which the account was acquired.
-   */
+    * The channel through which the account was acquired.
+    */
   channel?: string | null;
   /**
-   * An arbitrary subchannel string representing a distinction/subcategory within a broader channel.
-   */
+    * An arbitrary subchannel string representing a distinction/subcategory within a broader channel.
+    */
   subchannel?: string | null;
   /**
-   * An arbitrary identifier for the marketing campaign that led to the acquisition of this account.
-   */
+    * An arbitrary identifier for the marketing campaign that led to the acquisition of this account.
+    */
   campaign?: string | null;
 
 }
 
 export interface AccountAcquisitionCost {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * The amount of the corresponding currency used to acquire the account.
-   */
+    * The amount of the corresponding currency used to acquire the account.
+    */
   amount?: number | null;
 
 }
@@ -2779,362 +2780,362 @@ export interface ShippingAddressCreate {
   street2?: string | null;
   city?: string | null;
   /**
-   * State or province.
-   */
+    * State or province.
+    */
   region?: string | null;
   /**
-   * Zip or postal code.
-   */
+    * Zip or postal code.
+    */
   postalCode?: string | null;
   /**
-   * Country, 2-letter ISO code.
-   */
+    * Country, 2-letter ISO code.
+    */
   country?: string | null;
 
 }
 
 export interface Address {
   /**
-   * First name
-   */
+    * First name
+    */
   firstName?: string | null;
   /**
-   * Last name
-   */
+    * Last name
+    */
   lastName?: string | null;
   /**
-   * Phone number
-   */
+    * Phone number
+    */
   phone?: string | null;
   /**
-   * Street 1
-   */
+    * Street 1
+    */
   street1?: string | null;
   /**
-   * Street 2
-   */
+    * Street 2
+    */
   street2?: string | null;
   /**
-   * City
-   */
+    * City
+    */
   city?: string | null;
   /**
-   * State or province.
-   */
+    * State or province.
+    */
   region?: string | null;
   /**
-   * Zip or postal code.
-   */
+    * Zip or postal code.
+    */
   postalCode?: string | null;
   /**
-   * Country, 2-letter ISO code.
-   */
+    * Country, 2-letter ISO code.
+    */
   country?: string | null;
 
 }
 
 export interface BillingInfoCreate {
   /**
-   * A token [generated by Recurly.js](https://developers.recurly.com/reference/recurly-js/#getting-a-token).
-   */
+    * A token [generated by Recurly.js](https://developers.recurly.com/reference/recurly-js/#getting-a-token).
+    */
   tokenId?: string | null;
   /**
-   * First name
-   */
+    * First name
+    */
   firstName?: string | null;
   /**
-   * Last name
-   */
+    * Last name
+    */
   lastName?: string | null;
   /**
-   * Company name
-   */
+    * Company name
+    */
   company?: string | null;
   address?: Address | null;
   /**
-   * Credit card number, spaces and dashes are accepted.
-   */
+    * Credit card number, spaces and dashes are accepted.
+    */
   number?: string | null;
   /**
-   * Expiration month
-   */
+    * Expiration month
+    */
   month?: string | null;
   /**
-   * Expiration year
-   */
+    * Expiration year
+    */
   year?: string | null;
   /**
-   * *STRONGLY RECOMMENDED*
-   */
+    * *STRONGLY RECOMMENDED*
+    */
   cvv?: string | null;
   /**
-   * VAT number
-   */
+    * VAT number
+    */
   vatNumber?: string | null;
   /**
-   * *STRONGLY RECOMMENDED* Customer's IP address when updating their billing information.
-   */
+    * *STRONGLY RECOMMENDED* Customer's IP address when updating their billing information.
+    */
   ipAddress?: string | null;
   /**
-   * A token used in place of a credit card in order to perform transactions. Must be used in conjunction with `gateway_code`.
-   */
+    * A token used in place of a credit card in order to perform transactions. Must be used in conjunction with `gateway_code`.
+    */
   gatewayToken?: string | null;
   /**
-   * An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.
-   */
+    * An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.
+    */
   gatewayCode?: string | null;
   /**
-   * Amazon billing agreement ID
-   */
+    * Amazon billing agreement ID
+    */
   amazonBillingAgreementId?: string | null;
   /**
-   * PayPal billing agreement ID
-   */
+    * PayPal billing agreement ID
+    */
   paypalBillingAgreementId?: string | null;
   /**
-   * Fraud Session ID
-   */
+    * Fraud Session ID
+    */
   fraudSessionId?: string | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
   /**
-   * A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
-   */
+    * A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
+    */
   threeDSecureActionResultTokenId?: string | null;
   /**
-   * The International Bank Account Number, up to 34 alphanumeric characters comprising a country code; two check digits; and a number that includes the domestic bank account number, branch identifier, and potential routing information. (SEPA only)
-   */
+    * The International Bank Account Number, up to 34 alphanumeric characters comprising a country code; two check digits; and a number that includes the domestic bank account number, branch identifier, and potential routing information. (SEPA only)
+    */
   iban?: string | null;
   /**
-   * The name associated with the bank account (ACH, SEPA, Bacs only)
-   */
+    * The name associated with the bank account (ACH, SEPA, Bacs only)
+    */
   nameOnAccount?: string | null;
   /**
-   * The bank account number. (ACH, Bacs only)
-   */
+    * The bank account number. (ACH, Bacs only)
+    */
   accountNumber?: string | null;
   /**
-   * The bank's rounting number. (ACH only)
-   */
+    * The bank's rounting number. (ACH only)
+    */
   routingNumber?: string | null;
   /**
-   * Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
-   */
+    * Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
+    */
   sortCode?: string | null;
   /**
-   * The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
-   */
+    * The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+    */
   type?: string | null;
   /**
-   * The bank account type. (ACH only)
-   */
+    * The bank account type. (ACH only)
+    */
   accountType?: string | null;
   /**
-   * The `primary_payment_method` indicator is used to designate the primary billing info on the account. The first billing info created on an account will always become primary. Adding additional billing infos provides the flexibility to mark another billing info as primary, or adding additional non-primary billing infos. This can be accomplished by passing the `primary_payment_method` indicator. When adding billing infos via the billing_info and /accounts endpoints, this value is not permitted, and will return an error if provided.
-   */
+    * The `primary_payment_method` indicator is used to designate the primary billing info on the account. The first billing info created on an account will always become primary. Adding additional billing infos provides the flexibility to mark another billing info as primary, or adding additional non-primary billing infos. This can be accomplished by passing the `primary_payment_method` indicator. When adding billing infos via the billing_info and /accounts endpoints, this value is not permitted, and will return an error if provided.
+    */
   primaryPaymentMethod?: boolean | null;
 
 }
 
 export interface CustomField {
   /**
-   * Fields must be created in the UI before values can be assigned to them.
-   */
+    * Fields must be created in the UI before values can be assigned to them.
+    */
   name?: string | null;
   /**
-   * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
-   */
+    * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
+    */
   value?: string | null;
 
 }
 
 export interface AccountUpdate {
   /**
-   * A secondary value for the account.
-   */
+    * A secondary value for the account.
+    */
   username?: string | null;
   /**
-   * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
-   */
+    * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
+    */
   email?: string | null;
   /**
-   * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
-   */
+    * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
+    */
   preferredLocale?: string | null;
   /**
-   * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
-   */
+    * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
+    */
   ccEmails?: string | null;
   firstName?: string | null;
   lastName?: string | null;
   company?: string | null;
   /**
-   * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
-   */
+    * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
+    */
   vatNumber?: string | null;
   /**
-   * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
-   */
+    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
+    */
   taxExempt?: boolean | null;
   /**
-   * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
-   */
+    * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
+    */
   exemptionCertificate?: string | null;
   /**
-   * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
-   */
+    * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+    */
   parentAccountCode?: string | null;
   /**
-   * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
-   */
+    * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+    */
   parentAccountId?: string | null;
   /**
-   * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
-   */
+    * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
+    */
   billTo?: string | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
   address?: Address | null;
   billingInfo?: BillingInfoCreate | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
 
 }
 
 export interface CouponRedemptionCreate {
   /**
-   * Coupon ID
-   */
+    * Coupon ID
+    */
   couponId?: string | null;
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
 
 }
 
 export interface InvoiceCreate {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * An automatic invoice means a corresponding transaction is run using the account's billing information at the same time the invoice is created. Manual invoices are created without a corresponding transaction. The merchant must enter a manual payment transaction or have the customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH bank payment.
-   */
+    * An automatic invoice means a corresponding transaction is run using the account's billing information at the same time the invoice is created. Manual invoices are created without a corresponding transaction. The merchant must enter a manual payment transaction or have the customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH bank payment.
+    */
   collectionMethod?: string | null;
   /**
-   * This will default to the Customer Notes text specified on the Invoice Settings for charge invoices. Specify custom notes to add or override Customer Notes on charge invoices.
-   */
+    * This will default to the Customer Notes text specified on the Invoice Settings for charge invoices. Specify custom notes to add or override Customer Notes on charge invoices.
+    */
   chargeCustomerNotes?: string | null;
   /**
-   * This will default to the Customer Notes text specified on the Invoice Settings for credit invoices. Specify customer notes to add or override Customer Notes on credit invoices.
-   */
+    * This will default to the Customer Notes text specified on the Invoice Settings for credit invoices. Specify customer notes to add or override Customer Notes on credit invoices.
+    */
   creditCustomerNotes?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
-   */
+    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    */
   netTerms?: number | null;
   /**
-   * For manual invoicing, this identifies the PO number associated with the subscription.
-   */
+    * For manual invoicing, this identifies the PO number associated with the subscription.
+    */
   poNumber?: string | null;
   /**
-   * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions.
-   */
+    * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions.
+    */
   termsAndConditions?: string | null;
   /**
-   * VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
-   */
+    * VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
+    */
   vatReverseChargeNotes?: string | null;
 
 }
 
 export interface LineItemCreate {
   /**
-   * 3-letter ISO 4217 currency code. If `item_code`/`item_id` is part of the request then `currency` is optional, if the site has a single default currency. `currency` is required if `item_code`/`item_id` is present, and there are multiple currencies defined on the site. If `item_code`/`item_id` is not present `currency` is required.
-   */
+    * 3-letter ISO 4217 currency code. If `item_code`/`item_id` is part of the request then `currency` is optional, if the site has a single default currency. `currency` is required if `item_code`/`item_id` is present, and there are multiple currencies defined on the site. If `item_code`/`item_id` is not present `currency` is required.
+    */
   currency?: string | null;
   /**
-   * A positive or negative amount with `type=charge` will result in a positive `unit_amount`. A positive or negative amount with `type=credit` will result in a negative `unit_amount`. If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required. 
-   */
+    * A positive or negative amount with `type=charge` will result in a positive `unit_amount`. A positive or negative amount with `type=credit` will result in a negative `unit_amount`. If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required. 
+    */
   unitAmount?: number | null;
   /**
-   * This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
-   */
+    * This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
+    */
   quantity?: number | null;
   /**
-   * Description that appears on the invoice. If `item_code`/`item_id` is part of the request then `description` must be absent.
-   */
+    * Description that appears on the invoice. If `item_code`/`item_id` is part of the request then `description` must be absent.
+    */
   description?: string | null;
   /**
-   * Unique code to identify an item. Avaliable when the Credit Invoices and Subscription Billing Terms features are enabled.
-   */
+    * Unique code to identify an item. Avaliable when the Credit Invoices and Subscription Billing Terms features are enabled.
+    */
   itemCode?: string | null;
   /**
-   * System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
-   */
+    * System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+    */
   itemId?: string | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If `item_code`/`item_id` is not present then `type` is required.
-   */
+    * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If `item_code`/`item_id` is not present then `type` is required.
+    */
   type?: string | null;
   /**
-   * The reason the credit was given when line item is `type=credit`. When the Credit Invoices feature is enabled, the value can be set and will default to `general`. When the Credit Invoices feature is not enabled, the value will always be `null`.
-   */
+    * The reason the credit was given when line item is `type=credit`. When the Credit Invoices feature is enabled, the value can be set and will default to `general`. When the Credit Invoices feature is not enabled, the value will always be `null`.
+    */
   creditReasonCode?: string | null;
   /**
-   * Accounting Code for the `LineItem`. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
-   */
+    * Accounting Code for the `LineItem`. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
+    */
   accountingCode?: string | null;
   /**
-   * `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
-   */
+    * `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
+    */
   taxExempt?: boolean | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_transaction_type` must be absent.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_transaction_type` must be absent.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_service_type` must be absent.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_service_type` must be absent.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
-   */
+    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+    */
   taxCode?: string | null;
   /**
-   * Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.
-   */
+    * Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.
+    */
   productCode?: string | null;
   /**
-   * Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.  Origin `prepayment` is only allowed if `type` is `charge` and `tax_exempt` is left blank or set to true.  This origin creates a charge and opposite credit on the account to be used for future invoices.
-   */
+    * Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.  Origin `prepayment` is only allowed if `type` is `charge` and `tax_exempt` is left blank or set to true.  This origin creates a charge and opposite credit on the account to be used for future invoices.
+    */
   origin?: string | null;
   /**
-   * If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date. Defaults to the current date-time.
-   */
+    * If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date. Defaults to the current date-time.
+    */
   startDate?: Date | null;
   /**
-   * If this date is provided, it indicates the end of a time range.
-   */
+    * If this date is provided, it indicates the end of a time range.
+    */
   endDate?: Date | null;
 
 }
 
 export interface ShippingAddressUpdate {
   /**
-   * Shipping Address ID
-   */
+    * Shipping Address ID
+    */
   id?: string | null;
   nickname?: string | null;
   firstName?: string | null;
@@ -3147,332 +3148,332 @@ export interface ShippingAddressUpdate {
   street2?: string | null;
   city?: string | null;
   /**
-   * State or province.
-   */
+    * State or province.
+    */
   region?: string | null;
   /**
-   * Zip or postal code.
-   */
+    * Zip or postal code.
+    */
   postalCode?: string | null;
   /**
-   * Country, 2-letter ISO code.
-   */
+    * Country, 2-letter ISO code.
+    */
   country?: string | null;
 
 }
 
 export interface CouponCreate {
   /**
-   * The internal name for the coupon.
-   */
+    * The internal name for the coupon.
+    */
   name?: string | null;
   /**
-   * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
-   */
+    * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
+    */
   maxRedemptions?: number | null;
   /**
-   * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
-   */
+    * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
+    */
   maxRedemptionsPerAccount?: number | null;
   /**
-   * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
-   */
+    * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
+    */
   hostedDescription?: string | null;
   /**
-   * Description of the coupon on the invoice.
-   */
+    * Description of the coupon on the invoice.
+    */
   invoiceDescription?: string | null;
   /**
-   * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
-   */
+    * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
+    */
   redeemByDate?: string | null;
   /**
-   * The code the customer enters to redeem the coupon.
-   */
+    * The code the customer enters to redeem the coupon.
+    */
   code?: string | null;
   /**
-   * The type of discount provided by the coupon (how the amount discounted is calculated)
-   */
+    * The type of discount provided by the coupon (how the amount discounted is calculated)
+    */
   discountType?: string | null;
   /**
-   * The percent of the price discounted by the coupon.  Required if `discount_type` is `percent`.
-   */
+    * The percent of the price discounted by the coupon.  Required if `discount_type` is `percent`.
+    */
   discountPercent?: number | null;
   /**
-   * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine the duration of time the coupon is for.  Required if `discount_type` is `free_trial`.
-   */
+    * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine the duration of time the coupon is for.  Required if `discount_type` is `free_trial`.
+    */
   freeTrialUnit?: string | null;
   /**
-   * Sets the duration of time the `free_trial_unit` is for. Required if `discount_type` is `free_trial`.
-   */
+    * Sets the duration of time the `free_trial_unit` is for. Required if `discount_type` is `free_trial`.
+    */
   freeTrialAmount?: number | null;
   /**
-   * Fixed discount currencies by currency. Required if the coupon type is `fixed`. This parameter should contain the coupon discount values
-   */
+    * Fixed discount currencies by currency. Required if the coupon type is `fixed`. This parameter should contain the coupon discount values
+    */
   currencies?: CouponPricing[] | null;
   /**
-   * The coupon is valid for one-time, non-plan charges if true.
-   */
+    * The coupon is valid for one-time, non-plan charges if true.
+    */
   appliesToNonPlanCharges?: boolean | null;
   /**
-   * The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans. 
-   */
+    * The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans. 
+    */
   appliesToAllPlans?: boolean | null;
   /**
-   * To apply coupon to Items in your Catalog, include a list of `item_codes` in the request that the coupon will apply to. Or set value to true to apply to all Items in your Catalog. The following values are not permitted when `applies_to_all_items` is included: `free_trial_amount` and `free_trial_unit`. 
-   */
+    * To apply coupon to Items in your Catalog, include a list of `item_codes` in the request that the coupon will apply to. Or set value to true to apply to all Items in your Catalog. The following values are not permitted when `applies_to_all_items` is included: `free_trial_amount` and `free_trial_unit`. 
+    */
   appliesToAllItems?: boolean | null;
   /**
-   * List of plan codes to which this coupon applies. Required if `applies_to_all_plans` is false. Overrides `applies_to_all_plans` when `applies_to_all_plans` is true. 
-   */
+    * List of plan codes to which this coupon applies. Required if `applies_to_all_plans` is false. Overrides `applies_to_all_plans` when `applies_to_all_plans` is true. 
+    */
   planCodes?: string[] | null;
   /**
-   * List of item codes to which this coupon applies. Sending `item_codes` is only permitted when `applies_to_all_items` is set to false. The following values are not permitted when `item_codes` is included: `free_trial_amount` and `free_trial_unit`. 
-   */
+    * List of item codes to which this coupon applies. Sending `item_codes` is only permitted when `applies_to_all_items` is set to false. The following values are not permitted when `item_codes` is included: `free_trial_amount` and `free_trial_unit`. 
+    */
   itemCodes?: string[] | null;
   /**
-   * This field does not apply when the discount_type is `free_trial`. - "single_use" coupons applies to the first invoice only. - "temporal" coupons will apply to invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes. - "forever" coupons will apply to invoices forever. 
-   */
+    * This field does not apply when the discount_type is `free_trial`. - "single_use" coupons applies to the first invoice only. - "temporal" coupons will apply to invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes. - "forever" coupons will apply to invoices forever. 
+    */
   duration?: string | null;
   /**
-   * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
-   */
+    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+    */
   temporalAmount?: number | null;
   /**
-   * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
-   */
+    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+    */
   temporalUnit?: string | null;
   /**
-   * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
-   */
+    * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.
+    */
   couponType?: string | null;
   /**
-   * On a bulk coupon, the template from which unique coupon codes are generated. - You must start the template with your coupon_code wrapped in single quotes. - Outside of single quotes, use a 9 for a character that you want to be a random number. - Outside of single quotes, use an "x" for a character that you want to be a random letter. - Outside of single quotes, use an * for a character that you want to be a random number or letter. - Use single quotes ' ' for characters that you want to remain static. These strings can be alphanumeric and may contain a - _ or +. For example: "'abc-'****'-def'" 
-   */
+    * On a bulk coupon, the template from which unique coupon codes are generated. - You must start the template with your coupon_code wrapped in single quotes. - Outside of single quotes, use a 9 for a character that you want to be a random number. - Outside of single quotes, use an "x" for a character that you want to be a random letter. - Outside of single quotes, use an * for a character that you want to be a random number or letter. - Use single quotes ' ' for characters that you want to remain static. These strings can be alphanumeric and may contain a - _ or +. For example: "'abc-'****'-def'" 
+    */
   uniqueCodeTemplate?: string | null;
   /**
-   * Whether the discount is for all eligible charges on the account, or only a specific subscription.
-   */
+    * Whether the discount is for all eligible charges on the account, or only a specific subscription.
+    */
   redemptionResource?: string | null;
 
 }
 
 export interface CouponPricing {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * The fixed discount (in dollars) for the corresponding currency.
-   */
+    * The fixed discount (in dollars) for the corresponding currency.
+    */
   discount?: number | null;
 
 }
 
 export interface CouponUpdate {
   /**
-   * The internal name for the coupon.
-   */
+    * The internal name for the coupon.
+    */
   name?: string | null;
   /**
-   * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
-   */
+    * A maximum number of redemptions for the coupon. The coupon will expire when it hits its maximum redemptions.
+    */
   maxRedemptions?: number | null;
   /**
-   * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
-   */
+    * Redemptions per account is the number of times a specific account can redeem the coupon. Set redemptions per account to `1` if you want to keep customers from gaming the system and getting more than one discount from the coupon campaign.
+    */
   maxRedemptionsPerAccount?: number | null;
   /**
-   * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
-   */
+    * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or if you choose to show the description on your own checkout page.
+    */
   hostedDescription?: string | null;
   /**
-   * Description of the coupon on the invoice.
-   */
+    * Description of the coupon on the invoice.
+    */
   invoiceDescription?: string | null;
   /**
-   * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
-   */
+    * The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
+    */
   redeemByDate?: string | null;
 
 }
 
 export interface CouponBulkCreate {
   /**
-   * The quantity of unique coupon codes to generate
-   */
+    * The quantity of unique coupon codes to generate
+    */
   numberOfUniqueCodes?: number | null;
 
 }
 
 export interface ItemCreate {
   /**
-   * Unique code to identify the item.
-   */
+    * Unique code to identify the item.
+    */
   code?: string | null;
   /**
-   * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
-   */
+    * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
+    */
   name?: string | null;
   /**
-   * Optional, description.
-   */
+    * Optional, description.
+    */
   description?: string | null;
   /**
-   * Optional, stock keeping unit to link the item to other inventory systems.
-   */
+    * Optional, stock keeping unit to link the item to other inventory systems.
+    */
   externalSku?: string | null;
   /**
-   * Accounting code for invoice line items.
-   */
+    * Accounting code for invoice line items.
+    */
   accountingCode?: string | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
-   */
+    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+    */
   taxCode?: string | null;
   /**
-   * `true` exempts tax on the item, `false` applies tax on the item.
-   */
+    * `true` exempts tax on the item, `false` applies tax on the item.
+    */
   taxExempt?: boolean | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
   /**
-   * Item Pricing
-   */
+    * Item Pricing
+    */
   currencies?: Pricing[] | null;
 
 }
 
 export interface Pricing {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * Unit price
-   */
+    * Unit price
+    */
   unitAmount?: number | null;
 
 }
 
 export interface ItemUpdate {
   /**
-   * Unique code to identify the item.
-   */
+    * Unique code to identify the item.
+    */
   code?: string | null;
   /**
-   * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
-   */
+    * This name describes your item and will appear on the invoice when it's purchased on a one time basis.
+    */
   name?: string | null;
   /**
-   * Optional, description.
-   */
+    * Optional, description.
+    */
   description?: string | null;
   /**
-   * Optional, stock keeping unit to link the item to other inventory systems.
-   */
+    * Optional, stock keeping unit to link the item to other inventory systems.
+    */
   externalSku?: string | null;
   /**
-   * Accounting code for invoice line items.
-   */
+    * Accounting code for invoice line items.
+    */
   accountingCode?: string | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
-   */
+    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+    */
   taxCode?: string | null;
   /**
-   * `true` exempts tax on the item, `false` applies tax on the item.
-   */
+    * `true` exempts tax on the item, `false` applies tax on the item.
+    */
   taxExempt?: boolean | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
   /**
-   * Item Pricing
-   */
+    * Item Pricing
+    */
   currencies?: Pricing[] | null;
 
 }
 
 export interface MeasuredUnitCreate {
   /**
-   * Unique internal name of the measured unit on your site.
-   */
+    * Unique internal name of the measured unit on your site.
+    */
   name?: string | null;
   /**
-   * Display name for the measured unit.
-   */
+    * Display name for the measured unit.
+    */
   displayName?: string | null;
   /**
-   * Optional internal description.
-   */
+    * Optional internal description.
+    */
   description?: string | null;
 
 }
 
 export interface MeasuredUnitUpdate {
   /**
-   * Unique internal name of the measured unit on your site.
-   */
+    * Unique internal name of the measured unit on your site.
+    */
   name?: string | null;
   /**
-   * Display name for the measured unit.
-   */
+    * Display name for the measured unit.
+    */
   displayName?: string | null;
   /**
-   * Optional internal description.
-   */
+    * Optional internal description.
+    */
   description?: string | null;
 
 }
 
 export interface InvoiceUpdatable {
   /**
-   * This identifies the PO number associated with the invoice. Not editable for credit invoices.
-   */
+    * This identifies the PO number associated with the invoice. Not editable for credit invoices.
+    */
   poNumber?: string | null;
   /**
-   * VAT Reverse Charge Notes are editable only if there was a VAT reverse charge applied to the invoice.
-   */
+    * VAT Reverse Charge Notes are editable only if there was a VAT reverse charge applied to the invoice.
+    */
   vatReverseChargeNotes?: string | null;
   /**
-   * Terms and conditions are an optional note field. Not editable for credit invoices.
-   */
+    * Terms and conditions are an optional note field. Not editable for credit invoices.
+    */
   termsAndConditions?: string | null;
   /**
-   * Customer notes are an optional note field.
-   */
+    * Customer notes are an optional note field.
+    */
   customerNotes?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. Changing Net terms changes due_on, and the invoice could move between past due and pending.
-   */
+    * Integer representing the number of days after an invoice's creation that the invoice will become past due. Changing Net terms changes due_on, and the invoice could move between past due and pending.
+    */
   netTerms?: number | null;
   address?: InvoiceAddress | null;
 
@@ -3480,677 +3481,677 @@ export interface InvoiceUpdatable {
 
 export interface InvoiceAddress {
   /**
-   * Name on account
-   */
+    * Name on account
+    */
   nameOnAccount?: string | null;
   /**
-   * Company
-   */
+    * Company
+    */
   company?: string | null;
   /**
-   * First name
-   */
+    * First name
+    */
   firstName?: string | null;
   /**
-   * Last name
-   */
+    * Last name
+    */
   lastName?: string | null;
   /**
-   * Phone number
-   */
+    * Phone number
+    */
   phone?: string | null;
   /**
-   * Street 1
-   */
+    * Street 1
+    */
   street1?: string | null;
   /**
-   * Street 2
-   */
+    * Street 2
+    */
   street2?: string | null;
   /**
-   * City
-   */
+    * City
+    */
   city?: string | null;
   /**
-   * State or province.
-   */
+    * State or province.
+    */
   region?: string | null;
   /**
-   * Zip or postal code.
-   */
+    * Zip or postal code.
+    */
   postalCode?: string | null;
   /**
-   * Country, 2-letter ISO code.
-   */
+    * Country, 2-letter ISO code.
+    */
   country?: string | null;
 
 }
 
 export interface InvoiceCollect {
   /**
-   * A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
-   */
+    * A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
+    */
   threeDSecureActionResultTokenId?: string | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
   /**
-   * The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
-   */
+    * The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+    */
   billingInfoId?: string | null;
 
 }
 
 export interface ExternalTransaction {
   /**
-   * Payment method used for the external transaction.
-   */
+    * Payment method used for the external transaction.
+    */
   paymentMethod?: string | null;
   /**
-   * Used as the transaction's description.
-   */
+    * Used as the transaction's description.
+    */
   description?: string | null;
   /**
-   * The total amount of the transcaction. Cannot excceed the invoice total.
-   */
+    * The total amount of the transcaction. Cannot excceed the invoice total.
+    */
   amount?: number | null;
   /**
-   * Datetime that the external payment was collected. Defaults to current datetime.
-   */
+    * Datetime that the external payment was collected. Defaults to current datetime.
+    */
   collectedAt?: Date | null;
 
 }
 
 export interface InvoiceRefund {
   /**
-   * The type of refund. Amount and line items cannot both be specified in the request.
-   */
+    * The type of refund. Amount and line items cannot both be specified in the request.
+    */
   type?: string | null;
   /**
-   * The amount to be refunded. The amount will be split between the line items. If no amount is specified, it will default to refunding the total refundable amount on the invoice. 
-   */
+    * The amount to be refunded. The amount will be split between the line items. If no amount is specified, it will default to refunding the total refundable amount on the invoice. 
+    */
   amount?: number | null;
   /**
-   * The line items to be refunded. This is required when `type=line_items`.
-   */
+    * The line items to be refunded. This is required when `type=line_items`.
+    */
   lineItems?: LineItemRefund[] | null;
   /**
-   * Indicates how the invoice should be refunded when both a credit and transaction are present on the invoice: - `transaction_first` – Refunds the transaction first, then any amount is issued as credit back to the account. Default value when Credit Invoices feature is enabled. - `credit_first` – Issues credit back to the account first, then refunds any remaining amount back to the transaction. Default value when Credit Invoices feature is not enabled. - `all_credit` – Issues credit to the account for the entire amount of the refund. Only available when the Credit Invoices feature is enabled. - `all_transaction` – Refunds the entire amount back to transactions, using transactions from previous invoices if necessary. Only available when the Credit Invoices feature is enabled. 
-   */
+    * Indicates how the invoice should be refunded when both a credit and transaction are present on the invoice: - `transaction_first` – Refunds the transaction first, then any amount is issued as credit back to the account. Default value when Credit Invoices feature is enabled. - `credit_first` – Issues credit back to the account first, then refunds any remaining amount back to the transaction. Default value when Credit Invoices feature is not enabled. - `all_credit` – Issues credit to the account for the entire amount of the refund. Only available when the Credit Invoices feature is enabled. - `all_transaction` – Refunds the entire amount back to transactions, using transactions from previous invoices if necessary. Only available when the Credit Invoices feature is enabled. 
+    */
   refundMethod?: string | null;
   /**
-   * Used as the Customer Notes on the credit invoice.  This field can only be include when the Credit Invoices feature is enabled. 
-   */
+    * Used as the Customer Notes on the credit invoice.  This field can only be include when the Credit Invoices feature is enabled. 
+    */
   creditCustomerNotes?: string | null;
   /**
-   * Indicates that the refund was settled outside of Recurly, and a manual transaction should be created to track it in Recurly.  Required when: - refunding a manually collected charge invoice, and `refund_method` is not `all_credit` - refunding a credit invoice that refunded manually collecting invoices - refunding a credit invoice for a partial amount  This field can only be included when the Credit Invoices feature is enabled. 
-   */
+    * Indicates that the refund was settled outside of Recurly, and a manual transaction should be created to track it in Recurly.  Required when: - refunding a manually collected charge invoice, and `refund_method` is not `all_credit` - refunding a credit invoice that refunded manually collecting invoices - refunding a credit invoice for a partial amount  This field can only be included when the Credit Invoices feature is enabled. 
+    */
   externalRefund?: ExternalRefund | null;
 
 }
 
 export interface LineItemRefund {
   /**
-   * Line item ID
-   */
+    * Line item ID
+    */
   id?: string | null;
   /**
-   * Line item quantity to be refunded.
-   */
+    * Line item quantity to be refunded.
+    */
   quantity?: number | null;
   /**
-   * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used on line items that have a start and end date. 
-   */
+    * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used on line items that have a start and end date. 
+    */
   prorate?: boolean | null;
 
 }
 
 export interface ExternalRefund {
   /**
-   * Payment method used for external refund transaction.
-   */
+    * Payment method used for external refund transaction.
+    */
   paymentMethod?: string | null;
   /**
-   * Used as the refund transactions' description.
-   */
+    * Used as the refund transactions' description.
+    */
   description?: string | null;
   /**
-   * Date the external refund payment was made. Defaults to the current date-time.
-   */
+    * Date the external refund payment was made. Defaults to the current date-time.
+    */
   refundedAt?: Date | null;
 
 }
 
 export interface PlanCreate {
   /**
-   * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
-   */
+    * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
+    */
   code?: string | null;
   /**
-   * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
-   */
+    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
+    */
   name?: string | null;
   /**
-   * Optional description, not displayed.
-   */
+    * Optional description, not displayed.
+    */
   description?: string | null;
   /**
-   * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
-   */
+    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
+    */
   accountingCode?: string | null;
   /**
-   * Unit for the plan's billing interval.
-   */
+    * Unit for the plan's billing interval.
+    */
   intervalUnit?: string | null;
   /**
-   * Length of the plan's billing interval in `interval_unit`.
-   */
+    * Length of the plan's billing interval in `interval_unit`.
+    */
   intervalLength?: number | null;
   /**
-   * Units for the plan's trial period.
-   */
+    * Units for the plan's trial period.
+    */
   trialUnit?: string | null;
   /**
-   * Length of plan's trial period in `trial_units`. `0` means `no trial`.
-   */
+    * Length of plan's trial period in `trial_units`. `0` means `no trial`.
+    */
   trialLength?: number | null;
   /**
-   * Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
-   */
+    * Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
+    */
   trialRequiresBillingInfo?: boolean | null;
   /**
-   * Automatically terminate plans after a defined number of billing cycles.
-   */
+    * Automatically terminate plans after a defined number of billing cycles.
+    */
   totalBillingCycles?: number | null;
   /**
-   * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
-   */
+    * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
+    */
   autoRenew?: boolean | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * Setup fee revenue schedule type
-   */
+    * Setup fee revenue schedule type
+    */
   setupFeeRevenueScheduleType?: string | null;
   /**
-   * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
-   */
+    * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
+    */
   setupFeeAccountingCode?: string | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
-   */
+    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+    */
   taxCode?: string | null;
   /**
-   * `true` exempts tax on the plan, `false` applies tax on the plan.
-   */
+    * `true` exempts tax on the plan, `false` applies tax on the plan.
+    */
   taxExempt?: boolean | null;
   /**
-   * Pricing
-   */
+    * Pricing
+    */
   currencies?: PlanPricing[] | null;
   /**
-   * Hosted pages settings
-   */
+    * Hosted pages settings
+    */
   hostedPages?: PlanHostedPages | null;
   /**
-   * Add Ons
-   */
+    * Add Ons
+    */
   addOns?: AddOnCreate[] | null;
   /**
-   * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
-   */
+    * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
+    */
   allowAnyItemOnSubscriptions?: boolean | null;
 
 }
 
 export interface PlanPricing {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
-   */
+    * Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
+    */
   setupFee?: number | null;
   /**
-   * Unit price
-   */
+    * Unit price
+    */
   unitAmount?: number | null;
 
 }
 
 export interface PlanHostedPages {
   /**
-   * URL to redirect to after signup on the hosted payment pages.
-   */
+    * URL to redirect to after signup on the hosted payment pages.
+    */
   successUrl?: string | null;
   /**
-   * URL to redirect to on canceled signup on the hosted payment pages.
-   */
+    * URL to redirect to on canceled signup on the hosted payment pages.
+    */
   cancelUrl?: string | null;
   /**
-   * If `true`, the customer will be sent directly to your `success_url` after a successful signup, bypassing Recurly's hosted confirmation page.
-   */
+    * If `true`, the customer will be sent directly to your `success_url` after a successful signup, bypassing Recurly's hosted confirmation page.
+    */
   bypassConfirmation?: boolean | null;
   /**
-   * Determines if the quantity field is displayed on the hosted pages for the plan.
-   */
+    * Determines if the quantity field is displayed on the hosted pages for the plan.
+    */
   displayQuantity?: boolean | null;
 
 }
 
 export interface AddOnCreate {
   /**
-   * Unique code to identify an item. Avaliable when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
-   */
+    * Unique code to identify an item. Avaliable when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+    */
   itemCode?: string | null;
   /**
-   * System-generated unique identifier for an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
-   */
+    * System-generated unique identifier for an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+    */
   itemId?: string | null;
   /**
-   * The unique identifier for the add-on within its plan. If `item_code`/`item_id` is part of the request then `code` must be absent. If `item_code`/`item_id` is not present `code` is required.
-   */
+    * The unique identifier for the add-on within its plan. If `item_code`/`item_id` is part of the request then `code` must be absent. If `item_code`/`item_id` is not present `code` is required.
+    */
   code?: string | null;
   /**
-   * Describes your add-on and will appear in subscribers' invoices. If `item_code`/`item_id` is part of the request then `name` must be absent. If `item_code`/`item_id` is not present `name` is required.
-   */
+    * Describes your add-on and will appear in subscribers' invoices. If `item_code`/`item_id` is part of the request then `name` must be absent. If `item_code`/`item_id` is not present `name` is required.
+    */
   name?: string | null;
   /**
-   * Whether the add-on type is fixed, or usage-based.
-   */
+    * Whether the add-on type is fixed, or usage-based.
+    */
   addOnType?: string | null;
   /**
-   * Type of usage, required if `add_on_type` is `usage`. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons. 
-   */
+    * Type of usage, required if `add_on_type` is `usage`. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons. 
+    */
   usageType?: string | null;
   /**
-   * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.
-   */
+    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.
+    */
   usagePercentage?: number | null;
   /**
-   * System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
-   */
+    * System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
+    */
   measuredUnitId?: string | null;
   /**
-   * Name of a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
-   */
+    * Name of a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
+    */
   measuredUnitName?: string | null;
   /**
-   * Plan ID
-   */
+    * Plan ID
+    */
   planId?: string | null;
   /**
-   * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
-   */
+    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
+    */
   accountingCode?: string | null;
   /**
-   * When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
-   */
+    * When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
+    */
   revenueScheduleType?: string | null;
   /**
-   * Determines if the quantity field is displayed on the hosted pages for the add-on.
-   */
+    * Determines if the quantity field is displayed on the hosted pages for the add-on.
+    */
   displayQuantity?: boolean | null;
   /**
-   * Default quantity for the hosted pages.
-   */
+    * Default quantity for the hosted pages.
+    */
   defaultQuantity?: number | null;
   /**
-   * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
-   */
+    * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
+    */
   optional?: boolean | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
-   */
+    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
+    */
   taxCode?: string | null;
   /**
-   * * If `item_code`/`item_id` is part of the request and the item has a default currency then `currencies` is optional. If the item does not have a default currency, then `currencies` is required. If `item_code`/`item_id` is not present `currencies` is required. * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. 
-   */
+    * * If `item_code`/`item_id` is part of the request and the item has a default currency then `currencies` is optional. If the item does not have a default currency, then `currencies` is required. If `item_code`/`item_id` is not present `currencies` is required. * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. 
+    */
   currencies?: AddOnPricing[] | null;
   /**
-   * The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
-   */
+    * The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
+    */
   tierType?: string | null;
   /**
-   * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
-   */
+    * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+    */
   tiers?: Tier[] | null;
 
 }
 
 export interface AddOnPricing {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * Unit price
-   */
+    * Unit price
+    */
   unitAmount?: number | null;
 
 }
 
 export interface Tier {
   /**
-   * Ending quantity
-   */
+    * Ending quantity
+    */
   endingQuantity?: number | null;
   /**
-   * Tier pricing
-   */
+    * Tier pricing
+    */
   currencies?: Pricing[] | null;
 
 }
 
 export interface PlanUpdate {
   /**
-   * Plan ID
-   */
+    * Plan ID
+    */
   id?: string | null;
   /**
-   * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
-   */
+    * Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.
+    */
   code?: string | null;
   /**
-   * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
-   */
+    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
+    */
   name?: string | null;
   /**
-   * Optional description, not displayed.
-   */
+    * Optional description, not displayed.
+    */
   description?: string | null;
   /**
-   * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
-   */
+    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to plan's code.
+    */
   accountingCode?: string | null;
   /**
-   * Units for the plan's trial period.
-   */
+    * Units for the plan's trial period.
+    */
   trialUnit?: string | null;
   /**
-   * Length of plan's trial period in `trial_units`. `0` means `no trial`.
-   */
+    * Length of plan's trial period in `trial_units`. `0` means `no trial`.
+    */
   trialLength?: number | null;
   /**
-   * Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
-   */
+    * Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
+    */
   trialRequiresBillingInfo?: boolean | null;
   /**
-   * Automatically terminate plans after a defined number of billing cycles.
-   */
+    * Automatically terminate plans after a defined number of billing cycles.
+    */
   totalBillingCycles?: number | null;
   /**
-   * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
-   */
+    * Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
+    */
   autoRenew?: boolean | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * Setup fee revenue schedule type
-   */
+    * Setup fee revenue schedule type
+    */
   setupFeeRevenueScheduleType?: string | null;
   /**
-   * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
-   */
+    * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
+    */
   setupFeeAccountingCode?: string | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
-   */
+    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+    */
   taxCode?: string | null;
   /**
-   * `true` exempts tax on the plan, `false` applies tax on the plan.
-   */
+    * `true` exempts tax on the plan, `false` applies tax on the plan.
+    */
   taxExempt?: boolean | null;
   /**
-   * Pricing
-   */
+    * Pricing
+    */
   currencies?: PlanPricing[] | null;
   /**
-   * Hosted pages settings
-   */
+    * Hosted pages settings
+    */
   hostedPages?: PlanHostedPages | null;
   /**
-   * Add Ons
-   */
+    * Add Ons
+    */
   addOns?: AddOnCreate[] | null;
   /**
-   * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
-   */
+    * Used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used. 
+    */
   allowAnyItemOnSubscriptions?: boolean | null;
 
 }
 
 export interface AddOnUpdate {
   /**
-   * Add-on ID
-   */
+    * Add-on ID
+    */
   id?: string | null;
   /**
-   * The unique identifier for the add-on within its plan. If an `Item` is associated to the `AddOn` then `code` must be absent.
-   */
+    * The unique identifier for the add-on within its plan. If an `Item` is associated to the `AddOn` then `code` must be absent.
+    */
   code?: string | null;
   /**
-   * Describes your add-on and will appear in subscribers' invoices. If an `Item` is associated to the `AddOn` then `name` must be absent.
-   */
+    * Describes your add-on and will appear in subscribers' invoices. If an `Item` is associated to the `AddOn` then `name` must be absent.
+    */
   name?: string | null;
   /**
-   * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.
-   */
+    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.
+    */
   usagePercentage?: number | null;
   /**
-   * System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
-   */
+    * System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
+    */
   measuredUnitId?: string | null;
   /**
-   * Name of a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
-   */
+    * Name of a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
+    */
   measuredUnitName?: string | null;
   /**
-   * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If an `Item` is associated to the `AddOn` then `accounting code` must be absent.
-   */
+    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If an `Item` is associated to the `AddOn` then `accounting code` must be absent.
+    */
   accountingCode?: string | null;
   /**
-   * When this add-on is invoiced, the line item will use this revenue schedule. If an `Item` is associated to the `AddOn` then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
-   */
+    * When this add-on is invoiced, the line item will use this revenue schedule. If an `Item` is associated to the `AddOn` then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
+    */
   revenueScheduleType?: string | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.
+    */
   avalaraTransactionType?: number | null;
   /**
-   * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.
-   */
+    * Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.
+    */
   avalaraServiceType?: number | null;
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If an `Item` is associated to the `AddOn` then `tax code` must be absent.
-   */
+    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If an `Item` is associated to the `AddOn` then `tax code` must be absent.
+    */
   taxCode?: string | null;
   /**
-   * Determines if the quantity field is displayed on the hosted pages for the add-on.
-   */
+    * Determines if the quantity field is displayed on the hosted pages for the add-on.
+    */
   displayQuantity?: boolean | null;
   /**
-   * Default quantity for the hosted pages.
-   */
+    * Default quantity for the hosted pages.
+    */
   defaultQuantity?: number | null;
   /**
-   * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
-   */
+    * Whether the add-on is optional for the customer to include in their purchase on the hosted payment page. If false, the add-on will be included when a subscription is created through the Recurly UI. However, the add-on will not be included when a subscription is created through the API.
+    */
   optional?: boolean | null;
   /**
-   * If the add-on's `tier_type` is `tiered`, `volume` or `stairstep`, then `currencies` must be absent. 
-   */
+    * If the add-on's `tier_type` is `tiered`, `volume` or `stairstep`, then `currencies` must be absent. 
+    */
   currencies?: AddOnPricing[] | null;
   /**
-   * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
-   */
+    * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+    */
   tiers?: Tier[] | null;
 
 }
 
 export interface ShippingMethodCreate {
   /**
-   * The internal name used identify the shipping method.
-   */
+    * The internal name used identify the shipping method.
+    */
   code?: string | null;
   /**
-   * The name of the shipping method displayed to customers.
-   */
+    * The name of the shipping method displayed to customers.
+    */
   name?: string | null;
   /**
-   * Accounting code for shipping method.
-   */
+    * Accounting code for shipping method.
+    */
   accountingCode?: string | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
-   */
+    * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
+    */
   taxCode?: string | null;
 
 }
 
 export interface ShippingMethodUpdate {
   /**
-   * The internal name used identify the shipping method.
-   */
+    * The internal name used identify the shipping method.
+    */
   code?: string | null;
   /**
-   * The name of the shipping method displayed to customers.
-   */
+    * The name of the shipping method displayed to customers.
+    */
   name?: string | null;
   /**
-   * Accounting code for shipping method.
-   */
+    * Accounting code for shipping method.
+    */
   accountingCode?: string | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
-   */
+    * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific to each tax system. If you are using Recurly’s built-in taxes the values are:  - `FR` – Common Carrier FOB Destination - `FR022000` – Common Carrier FOB Origin - `FR020400` – Non Common Carrier FOB Destination - `FR020500` – Non Common Carrier FOB Origin - `FR010100` – Delivery by Company Vehicle Before Passage of Title - `FR010200` – Delivery by Company Vehicle After Passage of Title - `NT` – Non-Taxable 
+    */
   taxCode?: string | null;
 
 }
 
 export interface SubscriptionCreate {
   /**
-   * You must provide either a `plan_code` or `plan_id`. If both are provided the `plan_id` will be used.
-   */
+    * You must provide either a `plan_code` or `plan_id`. If both are provided the `plan_id` will be used.
+    */
   planCode?: string | null;
   /**
-   * You must provide either a `plan_code` or `plan_id`. If both are provided the `plan_id` will be used.
-   */
+    * You must provide either a `plan_code` or `plan_id`. If both are provided the `plan_id` will be used.
+    */
   planId?: string | null;
   account?: AccountCreate | null;
   /**
-   * Create a shipping address on the account and assign it to the subscription.
-   */
+    * Create a shipping address on the account and assign it to the subscription.
+    */
   shipping?: SubscriptionShippingCreate | null;
   /**
-   * Collection method
-   */
+    * Collection method
+    */
   collectionMethod?: string | null;
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   /**
-   * Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
-   */
+    * Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
+    */
   unitAmount?: number | null;
   /**
-   * Optionally override the default quantity of 1.
-   */
+    * Optionally override the default quantity of 1.
+    */
   quantity?: number | null;
   /**
-   * Add-ons
-   */
+    * Add-ons
+    */
   addOns?: SubscriptionAddOnCreate[] | null;
   /**
-   * Optional coupon code to redeem on the account and discount the subscription. Please note, the subscription request will fail if the coupon is invalid.
-   */
+    * Optional coupon code to redeem on the account and discount the subscription. Please note, the subscription request will fail if the coupon is invalid.
+    */
   couponCode?: string | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
   /**
-   * If set, overrides the default trial behavior for the subscription. The date must be in the future.
-   */
+    * If set, overrides the default trial behavior for the subscription. The date must be in the future.
+    */
   trialEndsAt?: Date | null;
   /**
-   * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
-   */
+    * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+    */
   startsAt?: Date | null;
   /**
-   * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.
-   */
+    * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.
+    */
   nextBillDate?: Date | null;
   /**
-   * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
-   */
+    * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
+    */
   totalBillingCycles?: number | null;
   /**
-   * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
-   */
+    * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
+    */
   renewalBillingCycles?: number | null;
   /**
-   * Whether the subscription renews at the end of its term.
-   */
+    * Whether the subscription renews at the end of its term.
+    */
   autoRenew?: boolean | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
-   */
+    * This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
+    */
   termsAndConditions?: string | null;
   /**
-   * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.
-   */
+    * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.
+    */
   customerNotes?: string | null;
   /**
-   * If there are pending credits on the account that will be invoiced during the subscription creation, these will be used as the Customer Notes on the credit invoice.
-   */
+    * If there are pending credits on the account that will be invoiced during the subscription creation, these will be used as the Customer Notes on the credit invoice.
+    */
   creditCustomerNotes?: string | null;
   /**
-   * For manual invoicing, this identifies the PO number associated with the subscription.
-   */
+    * For manual invoicing, this identifies the PO number associated with the subscription.
+    */
   poNumber?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
-   */
+    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    */
   netTerms?: number | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
 
 }
@@ -4158,514 +4159,514 @@ export interface SubscriptionCreate {
 export interface SubscriptionShippingCreate {
   address?: ShippingAddressCreate | null;
   /**
-   * Assign a shipping address from the account's existing shipping addresses. If `address_id` and `address` are both present, `address` will be used.
-   */
+    * Assign a shipping address from the account's existing shipping addresses. If `address_id` and `address` are both present, `address` will be used.
+    */
   addressId?: string | null;
   /**
-   * The id of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The id of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodId?: string | null;
   /**
-   * The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodCode?: string | null;
   /**
-   * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
-   */
+    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
+    */
   amount?: number | null;
 
 }
 
 export interface SubscriptionAddOnCreate {
   /**
-   * If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be used. If `add_on_source` is set to `item`, then the `code` from the associated item should be used. 
-   */
+    * If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be used. If `add_on_source` is set to `item`, then the `code` from the associated item should be used. 
+    */
   code?: string | null;
   /**
-   * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add_on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
-   */
+    * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add_on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
+    */
   addOnSource?: string | null;
   /**
-   * Quantity
-   */
+    * Quantity
+    */
   quantity?: number | null;
   /**
-   * * Optionally, override the add-on's default unit amount. * If the plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `unit_amount` must be absent. 
-   */
+    * * Optionally, override the add-on's default unit amount. * If the plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `unit_amount` must be absent. 
+    */
   unitAmount?: number | null;
   /**
-   * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
-   */
+    * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
+    */
   tiers?: SubscriptionAddOnTier[] | null;
   /**
-   * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons.
-   */
+    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons.
+    */
   usagePercentage?: number | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
 
 }
 
 export interface SubscriptionAddOnTier {
   /**
-   * Ending quantity
-   */
+    * Ending quantity
+    */
   endingQuantity?: number | null;
   /**
-   * Unit amount
-   */
+    * Unit amount
+    */
   unitAmount?: number | null;
 
 }
 
 export interface SubscriptionUpdate {
   /**
-   * Change collection method
-   */
+    * Change collection method
+    */
   collectionMethod?: string | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
   /**
-   * The remaining billing cycles in the current term.
-   */
+    * The remaining billing cycles in the current term.
+    */
   remainingBillingCycles?: number | null;
   /**
-   * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
-   */
+    * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
+    */
   renewalBillingCycles?: number | null;
   /**
-   * Whether the subscription renews at the end of its term.
-   */
+    * Whether the subscription renews at the end of its term.
+    */
   autoRenew?: boolean | null;
   /**
-   * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. For a subscription in a trial period, this will change when the trial expires. This parameter is useful for postponement of a subscription to change its billing date without proration.
-   */
+    * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. For a subscription in a trial period, this will change when the trial expires. This parameter is useful for postponement of a subscription to change its billing date without proration.
+    */
   nextBillDate?: Date | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
-   */
+    * Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.
+    */
   termsAndConditions?: string | null;
   /**
-   * Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.
-   */
+    * Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.
+    */
   customerNotes?: string | null;
   /**
-   * For manual invoicing, this identifies the PO number associated with the subscription.
-   */
+    * For manual invoicing, this identifies the PO number associated with the subscription.
+    */
   poNumber?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
-   */
+    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    */
   netTerms?: number | null;
   /**
-   * Subscription shipping details
-   */
+    * Subscription shipping details
+    */
   shipping?: SubscriptionShippingUpdate | null;
   /**
-   * The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
-   */
+    * The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+    */
   billingInfoId?: string | null;
 
 }
 
 export interface SubscriptionShippingUpdate {
   /**
-   * Object type
-   */
+    * Object type
+    */
   object?: string | null;
   address?: ShippingAddressCreate | null;
   /**
-   * Assign a shipping address from the account's existing shipping addresses.
-   */
+    * Assign a shipping address from the account's existing shipping addresses.
+    */
   addressId?: string | null;
 
 }
 
 export interface SubscriptionCancel {
   /**
-   * The timeframe parameter controls when the expiration takes place. The `bill_date` timeframe causes the subscription to expire when the subscription is scheduled to bill next. The `term_end` timeframe causes the subscription to continue to bill until the end of the subscription term, then expire.
-   */
+    * The timeframe parameter controls when the expiration takes place. The `bill_date` timeframe causes the subscription to expire when the subscription is scheduled to bill next. The `term_end` timeframe causes the subscription to continue to bill until the end of the subscription term, then expire.
+    */
   timeframe?: string | null;
 
 }
 
 export interface SubscriptionPause {
   /**
-   * Number of billing cycles to pause the subscriptions.
-   */
+    * Number of billing cycles to pause the subscriptions.
+    */
   remainingPauseCycles?: number | null;
 
 }
 
 export interface SubscriptionChangeCreate {
   /**
-   * The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription term ends. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe option is accepted as an alias for `term_end`.
-   */
+    * The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription term ends. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe option is accepted as an alias for `term_end`.
+    */
   timeframe?: string | null;
   /**
-   * If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.
-   */
+    * If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.
+    */
   planId?: string | null;
   /**
-   * If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.
-   */
+    * If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.
+    */
   planCode?: string | null;
   /**
-   * Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.
-   */
+    * Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.
+    */
   unitAmount?: number | null;
   /**
-   * Optionally override the default quantity of 1.
-   */
+    * Optionally override the default quantity of 1.
+    */
   quantity?: number | null;
   /**
-   * The shipping address can currently only be changed immediately, using SubscriptionUpdate.
-   */
+    * The shipping address can currently only be changed immediately, using SubscriptionUpdate.
+    */
   shipping?: SubscriptionChangeShippingCreate | null;
   /**
-   * A list of coupon_codes to be redeemed on the subscription during the change. Only allowed if timeframe is now and you change something about the subscription that creates an invoice.
-   */
+    * A list of coupon_codes to be redeemed on the subscription during the change. Only allowed if timeframe is now and you change something about the subscription that creates an invoice.
+    */
   couponCodes?: string[] | null;
   /**
-   * If this value is omitted your existing add-ons will be removed. If you provide a value for this field it will replace any existing add-ons. So, when adding or modifying an add-on, you need to include the existing subscription add-ons. Unchanged add-ons can be included just using the subscription add-on's ID: `{"id": "abc123"}`.  If a subscription add-on's `code` is supplied without the `id`, `{"code": "def456"}`, the subscription add-on attributes will be set to the current values of the plan add-on unless provided in the request.  - If an `id` is passed, any attributes not passed in will pull from the   existing subscription add-on - If a `code` is passed, any attributes not passed in will pull from the   current values of the plan add-on - Attributes passed in as part of the request will override either of the   above scenarios 
-   */
+    * If this value is omitted your existing add-ons will be removed. If you provide a value for this field it will replace any existing add-ons. So, when adding or modifying an add-on, you need to include the existing subscription add-ons. Unchanged add-ons can be included just using the subscription add-on's ID: `{"id": "abc123"}`.  If a subscription add-on's `code` is supplied without the `id`, `{"code": "def456"}`, the subscription add-on attributes will be set to the current values of the plan add-on unless provided in the request.  - If an `id` is passed, any attributes not passed in will pull from the   existing subscription add-on - If a `code` is passed, any attributes not passed in will pull from the   current values of the plan add-on - Attributes passed in as part of the request will override either of the   above scenarios 
+    */
   addOns?: SubscriptionAddOnUpdate[] | null;
   /**
-   * Collection method
-   */
+    * Collection method
+    */
   collectionMethod?: string | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
   /**
-   * For manual invoicing, this identifies the PO number associated with the subscription.
-   */
+    * For manual invoicing, this identifies the PO number associated with the subscription.
+    */
   poNumber?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
-   */
+    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    */
   netTerms?: number | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
 
 }
 
 export interface SubscriptionChangeShippingCreate {
   /**
-   * The id of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The id of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodId?: string | null;
   /**
-   * The code of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The code of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodCode?: string | null;
   /**
-   * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
-   */
+    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
+    */
   amount?: number | null;
 
 }
 
 export interface SubscriptionAddOnUpdate {
   /**
-   * When an id is provided, the existing subscription add-on attributes will persist unless overridden in the request. 
-   */
+    * When an id is provided, the existing subscription add-on attributes will persist unless overridden in the request. 
+    */
   id?: string | null;
   /**
-   * If a code is provided without an id, the subscription add-on attributes will be set to the current value for those attributes on the plan add-on unless provided in the request. If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be used. If `add_on_source` is set to `item`, then the `code` from the associated item should be used. 
-   */
+    * If a code is provided without an id, the subscription add-on attributes will be set to the current value for those attributes on the plan add-on unless provided in the request. If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be used. If `add_on_source` is set to `item`, then the `code` from the associated item should be used. 
+    */
   code?: string | null;
   /**
-   * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add_on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
-   */
+    * Used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add_on data will be pulled from the plan's add-ons. If the associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog. 
+    */
   addOnSource?: string | null;
   /**
-   * Quantity
-   */
+    * Quantity
+    */
   quantity?: number | null;
   /**
-   * Optionally, override the add-on's default unit amount.
-   */
+    * Optionally, override the add-on's default unit amount.
+    */
   unitAmount?: number | null;
   /**
-   * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
-   */
+    * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount`. There must be one tier with an `ending_quantity` of 999999999 which is the default if not provided. 
+    */
   tiers?: SubscriptionAddOnTier[] | null;
   /**
-   * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
-   */
+    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
+    */
   usagePercentage?: number | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
 
 }
 
 export interface UsageCreate {
   /**
-   * Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
-   */
+    * Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
+    */
   merchantTag?: string | null;
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
-   */
+    * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+    */
   amount?: number | null;
   /**
-   * When the usage was recorded in your system.
-   */
+    * When the usage was recorded in your system.
+    */
   recordingTimestamp?: Date | null;
   /**
-   * When the usage actually happened. This will define the line item dates this usage is billed under and is important for revenue recognition.
-   */
+    * When the usage actually happened. This will define the line item dates this usage is billed under and is important for revenue recognition.
+    */
   usageTimestamp?: Date | null;
 
 }
 
 export interface PurchaseCreate {
   /**
-   * 3-letter ISO 4217 currency code.
-   */
+    * 3-letter ISO 4217 currency code.
+    */
   currency?: string | null;
   account?: AccountPurchase | null;
   /**
-   * Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.
-   */
+    * Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.
+    */
   collectionMethod?: string | null;
   /**
-   * For manual invoicing, this identifies the PO number associated with the subscription.
-   */
+    * For manual invoicing, this identifies the PO number associated with the subscription.
+    */
   poNumber?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
-   */
+    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    */
   netTerms?: number | null;
   /**
-   * Terms and conditions to be put on the purchase invoice.
-   */
+    * Terms and conditions to be put on the purchase invoice.
+    */
   termsAndConditions?: string | null;
   /**
-   * Customer notes
-   */
+    * Customer notes
+    */
   customerNotes?: string | null;
   /**
-   * VAT reverse charge notes for cross border European tax settlement.
-   */
+    * VAT reverse charge notes for cross border European tax settlement.
+    */
   vatReverseChargeNotes?: string | null;
   /**
-   * Notes to be put on the credit invoice resulting from credits in the purchase, if any.
-   */
+    * Notes to be put on the credit invoice resulting from credits in the purchase, if any.
+    */
   creditCustomerNotes?: string | null;
   /**
-   * The default payment gateway identifier to be used for the purchase transaction.  This will also be applied as the default for any subscriptions included in the purchase request.
-   */
+    * The default payment gateway identifier to be used for the purchase transaction.  This will also be applied as the default for any subscriptions included in the purchase request.
+    */
   gatewayCode?: string | null;
   shipping?: ShippingPurchase | null;
   /**
-   * A list of one time charges or credits to be created with the purchase.
-   */
+    * A list of one time charges or credits to be created with the purchase.
+    */
   lineItems?: LineItemCreate[] | null;
   /**
-   * A list of subscriptions to be created with the purchase.
-   */
+    * A list of subscriptions to be created with the purchase.
+    */
   subscriptions?: SubscriptionPurchase[] | null;
   /**
-   * A list of coupon_codes to be redeemed on the subscription or account during the purchase.
-   */
+    * A list of coupon_codes to be redeemed on the subscription or account during the purchase.
+    */
   couponCodes?: string[] | null;
   /**
-   * A gift card redemption code to be redeemed on the purchase invoice.
-   */
+    * A gift card redemption code to be redeemed on the purchase invoice.
+    */
   giftCardRedemptionCode?: string | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
 
 }
 
 export interface AccountPurchase {
   /**
-   * Optional, but if present allows an existing account to be used and updated as part of the purchase.
-   */
+    * Optional, but if present allows an existing account to be used and updated as part of the purchase.
+    */
   id?: string | null;
   /**
-   * The unique identifier of the account. This cannot be changed once the account is created.
-   */
+    * The unique identifier of the account. This cannot be changed once the account is created.
+    */
   code?: string | null;
   acquisition?: AccountAcquisitionUpdatable | null;
   /**
-   * A secondary value for the account.
-   */
+    * A secondary value for the account.
+    */
   username?: string | null;
   /**
-   * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
-   */
+    * The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
+    */
   email?: string | null;
   /**
-   * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
-   */
+    * Used to determine the language and locale of emails sent on behalf of the merchant to the customer. The list of locales is restricted to those the merchant has enabled on the site.
+    */
   preferredLocale?: string | null;
   /**
-   * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
-   */
+    * Additional email address that should receive account correspondence. These should be separated only by commas. These CC emails will receive all emails that the `email` field also receives.
+    */
   ccEmails?: string | null;
   firstName?: string | null;
   lastName?: string | null;
   company?: string | null;
   /**
-   * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
-   */
+    * The VAT number of the account (to avoid having the VAT applied). This is only used for manually collected invoices.
+    */
   vatNumber?: string | null;
   /**
-   * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
-   */
+    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.
+    */
   taxExempt?: boolean | null;
   /**
-   * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
-   */
+    * The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
+    */
   exemptionCertificate?: string | null;
   /**
-   * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
-   */
+    * The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+    */
   parentAccountCode?: string | null;
   /**
-   * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
-   */
+    * The UUID of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
+    */
   parentAccountId?: string | null;
   /**
-   * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
-   */
+    * An enumerable describing the billing behavior of the account, specifically whether the account is self-paying or will rely on the parent account to pay.
+    */
   billTo?: string | null;
   /**
-   * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
-   */
+    * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
+    */
   transactionType?: string | null;
   address?: Address | null;
   billingInfo?: BillingInfoCreate | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
 
 }
 
 export interface ShippingPurchase {
   /**
-   * Assign a shipping address from the account's existing shipping addresses. If this and `address` are both present, `address` will take precedence.
-   */
+    * Assign a shipping address from the account's existing shipping addresses. If this and `address` are both present, `address` will take precedence.
+    */
   addressId?: string | null;
   address?: ShippingAddressCreate | null;
   /**
-   * A list of shipping fees to be created as charges with the purchase.
-   */
+    * A list of shipping fees to be created as charges with the purchase.
+    */
   fees?: ShippingFeeCreate[] | null;
 
 }
 
 export interface ShippingFeeCreate {
   /**
-   * The id of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The id of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodId?: string | null;
   /**
-   * The code of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The code of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodCode?: string | null;
   /**
-   * This is priced in the purchase's currency.
-   */
+    * This is priced in the purchase's currency.
+    */
   amount?: number | null;
 
 }
 
 export interface SubscriptionPurchase {
   /**
-   * Plan code
-   */
+    * Plan code
+    */
   planCode?: string | null;
   /**
-   * Plan ID
-   */
+    * Plan ID
+    */
   planId?: string | null;
   /**
-   * Override the unit amount of the subscription plan by setting this value in cents. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
-   */
+    * Override the unit amount of the subscription plan by setting this value in cents. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
+    */
   unitAmount?: number | null;
   /**
-   * Optionally override the default quantity of 1.
-   */
+    * Optionally override the default quantity of 1.
+    */
   quantity?: number | null;
   /**
-   * Add-ons
-   */
+    * Add-ons
+    */
   addOns?: SubscriptionAddOnCreate[] | null;
   /**
-   * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-   */
+    * The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
+    */
   customFields?: CustomField[] | null;
   /**
-   * Create a shipping address on the account and assign it to the subscription.
-   */
+    * Create a shipping address on the account and assign it to the subscription.
+    */
   shipping?: SubscriptionShippingPurchase | null;
   /**
-   * If set, overrides the default trial behavior for the subscription. The date must be in the future.
-   */
+    * If set, overrides the default trial behavior for the subscription. The date must be in the future.
+    */
   trialEndsAt?: Date | null;
   /**
-   * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
-   */
+    * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+    */
   startsAt?: Date | null;
   /**
-   * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.
-   */
+    * If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.
+    */
   nextBillDate?: Date | null;
   /**
-   * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
-   */
+    * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
+    */
   totalBillingCycles?: number | null;
   /**
-   * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
-   */
+    * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
+    */
   renewalBillingCycles?: number | null;
   /**
-   * Whether the subscription renews at the end of its term.
-   */
+    * Whether the subscription renews at the end of its term.
+    */
   autoRenew?: boolean | null;
   /**
-   * Revenue schedule type
-   */
+    * Revenue schedule type
+    */
   revenueScheduleType?: string | null;
 
 }
 
 export interface SubscriptionShippingPurchase {
   /**
-   * The id of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The id of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodId?: string | null;
   /**
-   * The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
-   */
+    * The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.
+    */
   methodCode?: string | null;
   /**
-   * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
-   */
+    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
+    */
   amount?: number | null;
 
 }
@@ -4686,8 +4687,8 @@ export declare class Client {
    *   console.log(site.subdomain)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -4699,16 +4700,16 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<Site>} A list of sites.
    */
-  listSites(params?: object): Pager<Site>;
+  listSites(options?: object): Pager<Site>;
   /**
    * Fetch a site
    *
@@ -4730,7 +4731,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param siteId - Site ID or subdomain. For ID no prefix is used e.g. `e28zov4fw0v2`. For subdomain use prefix `subdomain-`, e.g. `subdomain-recurly`.
+   * @param {string} siteId - Site ID or subdomain. For ID no prefix is used e.g. `e28zov4fw0v2`. For subdomain use prefix `subdomain-`, e.g. `subdomain-recurly`.
    * @return {Promise<Site>} A site.
    */
   getSite(siteId: string): Promise<Site>;
@@ -4746,8 +4747,8 @@ export declare class Client {
    *   console.log(account.code)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -4759,26 +4760,26 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-   * @param params.subscriber - Filter for accounts with or without a subscription in the `active`,
+   * @param {string} options.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+   * @param {boolean} options.subscriber - Filter for accounts with or without a subscription in the `active`,
    *   `canceled`, or `future` state.
    *   
-   * @param params.pastDue - Filter for accounts with an invoice in the `past_due` state.
+   * @param {string} options.pastDue - Filter for accounts with an invoice in the `past_due` state.
    * @return {Pager<Account>} A list of the site's accounts.
    */
-  listAccounts(params?: object): Pager<Account>;
+  listAccounts(options?: object): Pager<Account>;
   /**
    * Create an account
    *
@@ -4812,7 +4813,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountCreate}
+   * @param {AccountCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountCreate}
    * @return {Promise<Account>} An account.
    */
   createAccount(body: AccountCreate): Promise<Account>;
@@ -4837,7 +4838,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
   getAccount(accountId: string): Promise<Account>;
@@ -4866,8 +4867,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountUpdate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {AccountUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountUpdate}
    * @return {Promise<Account>} An account.
    */
   updateAccount(accountId: string, body: AccountUpdate): Promise<Account>;
@@ -4891,7 +4892,7 @@ export declare class Client {
    *   throw err
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
   deactivateAccount(accountId: string): Promise<Account>;
@@ -4916,7 +4917,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<AccountAcquisition>} An account's acquisition data.
    */
   getAccountAcquisition(accountId: string): Promise<AccountAcquisition>;
@@ -4946,8 +4947,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountAcquisitionUpdatable}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {AccountAcquisitionUpdatable} body - The object representing the JSON request to send to the server. It should conform to the schema of {AccountAcquisitionUpdatable}
    * @return {Promise<AccountAcquisition>} An account's updated acquisition data.
    */
   updateAccountAcquisition(accountId: string, body: AccountAcquisitionUpdatable): Promise<AccountAcquisition>;
@@ -4972,7 +4973,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Empty>} Acquisition data was succesfully deleted.
    */
   removeAccountAcquisition(accountId: string): Promise<Empty>;
@@ -4996,7 +4997,7 @@ export declare class Client {
    *   throw err
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Account>} An account.
    */
   reactivateAccount(accountId: string): Promise<Account>;
@@ -5021,7 +5022,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<AccountBalance>} An account's balance.
    */
   getAccountBalance(accountId: string): Promise<AccountBalance>;
@@ -5046,7 +5047,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<BillingInfo>} An account's billing information.
    */
   getBillingInfo(accountId: string): Promise<BillingInfo>;
@@ -5075,8 +5076,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {BillingInfoCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
    * @return {Promise<BillingInfo>} Updated billing information.
    */
   updateBillingInfo(accountId: string, body: BillingInfoCreate): Promise<BillingInfo>;
@@ -5101,7 +5102,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<Empty>} Billing information deleted
    */
   removeBillingInfo(accountId: string): Promise<Empty>;
@@ -5111,9 +5112,9 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/list_billing_infos
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5125,27 +5126,27 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<BillingInfo>} A list of the the billing information for an account's
    */
-  listBillingInfos(accountId: string, params?: object): Pager<BillingInfo>;
+  listBillingInfos(accountId: string, options?: object): Pager<BillingInfo>;
   /**
    * Set an account's billing information when the wallet feature is enabled
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/create_billing_info
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {BillingInfoCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
    * @return {Promise<BillingInfo>} Updated billing information.
    */
   createBillingInfo(accountId: string, body: BillingInfoCreate): Promise<BillingInfo>;
@@ -5155,8 +5156,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId - Billing Info ID.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} billingInfoId - Billing Info ID.
    * @return {Promise<BillingInfo>} A billing info.
    */
   getABillingInfo(accountId: string, billingInfoId: string): Promise<BillingInfo>;
@@ -5166,9 +5167,9 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId - Billing Info ID.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} billingInfoId - Billing Info ID.
+   * @param {BillingInfoCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoCreate}
    * @return {Promise<BillingInfo>} Updated billing information.
    */
   updateABillingInfo(accountId: string, billingInfoId: string, body: BillingInfoCreate): Promise<BillingInfo>;
@@ -5178,8 +5179,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId - Billing Info ID.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} billingInfoId - Billing Info ID.
    * @return {Promise<Empty>} Billing information deleted
    */
   removeABillingInfo(accountId: string, billingInfoId: string): Promise<Empty>;
@@ -5195,9 +5196,9 @@ export declare class Client {
    *   console.log(redemption.id)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5209,19 +5210,20 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
+   * @param {string} options.state - Filter by state.
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on an account.
    */
-  listAccountCouponRedemptions(accountId: string, params?: object): Pager<CouponRedemption>;
+  listAccountCouponRedemptions(accountId: string, options?: object): Pager<CouponRedemption>;
   /**
    * Show the coupon redemption that is active on an account
    *
@@ -5243,7 +5245,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<CouponRedemption>} An active coupon redemption on an account.
    */
   getActiveCouponRedemption(accountId: string): Promise<CouponRedemption>;
@@ -5253,8 +5255,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/create_coupon_redemption
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponRedemptionCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {CouponRedemptionCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponRedemptionCreate}
    * @return {Promise<CouponRedemption>} Returns the new coupon redemption.
    */
   createCouponRedemption(accountId: string, body: CouponRedemptionCreate): Promise<CouponRedemption>;
@@ -5279,7 +5281,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
    * @return {Promise<CouponRedemption>} Coupon redemption deleted.
    */
   removeCouponRedemption(accountId: string): Promise<CouponRedemption>;
@@ -5295,23 +5297,23 @@ export declare class Client {
    *   console.log(payment.uuid)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<CreditPayment>} A list of the account's credit payments.
    */
-  listAccountCreditPayments(accountId: string, params?: object): Pager<CreditPayment>;
+  listAccountCreditPayments(accountId: string, options?: object): Pager<CreditPayment>;
   /**
    * List an account's invoices
    *
@@ -5324,9 +5326,9 @@ export declare class Client {
    *   console.log(invoice.number)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5338,19 +5340,19 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.type - Filter by type when:
+   * @param {string} options.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -5358,7 +5360,7 @@ export declare class Client {
    *   
    * @return {Pager<Invoice>} A list of the account's invoices.
    */
-  listAccountInvoices(accountId: string, params?: object): Pager<Invoice>;
+  listAccountInvoices(accountId: string, options?: object): Pager<Invoice>;
   /**
    * Create an invoice for pending line items
    *
@@ -5386,8 +5388,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {InvoiceCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices.
    */
   createInvoice(accountId: string, body: InvoiceCreate): Promise<InvoiceCollection>;
@@ -5418,8 +5420,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {InvoiceCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCreate}
    * @return {Promise<InvoiceCollection>} Returns the invoice previews.
    */
   previewInvoice(accountId: string, body: InvoiceCreate): Promise<InvoiceCollection>;
@@ -5435,9 +5437,9 @@ export declare class Client {
    *   console.log(lineItem.id)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5449,24 +5451,24 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.original - Filter by original field.
-   * @param params.state - Filter by state field.
-   * @param params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the account's line items.
    */
-  listAccountLineItems(accountId: string, params?: object): Pager<LineItem>;
+  listAccountLineItems(accountId: string, options?: object): Pager<LineItem>;
   /**
    * Create a new line item for the account
    *
@@ -5493,8 +5495,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {LineItemCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {LineItemCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {LineItemCreate}
    * @return {Promise<LineItem>} Returns the new line item.
    */
   createLineItem(accountId: string, body: LineItemCreate): Promise<LineItem>;
@@ -5510,9 +5512,9 @@ export declare class Client {
    *   console.log(note.message)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5526,7 +5528,7 @@ export declare class Client {
    *   
    * @return {Pager<AccountNote>} A list of an account's notes.
    */
-  listAccountNotes(accountId: string, params?: object): Pager<AccountNote>;
+  listAccountNotes(accountId: string, options?: object): Pager<AccountNote>;
   /**
    * Fetch an account note
    *
@@ -5549,8 +5551,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param accountNoteId - Account Note ID.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} accountNoteId - Account Note ID.
    * @return {Promise<AccountNote>} An account note.
    */
   getAccountNote(accountId: string, accountNoteId: string): Promise<AccountNote>;
@@ -5566,9 +5568,9 @@ export declare class Client {
    *   console.log(address.street1)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5580,21 +5582,21 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<ShippingAddress>} A list of an account's shipping addresses.
    */
-  listShippingAddresses(accountId: string, params?: object): Pager<ShippingAddress>;
+  listShippingAddresses(accountId: string, options?: object): Pager<ShippingAddress>;
   /**
    * Create a new shipping address for the account
    *
@@ -5625,8 +5627,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressCreate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {ShippingAddressCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressCreate}
    * @return {Promise<ShippingAddress>} Returns the new shipping address.
    */
   createShippingAddress(accountId: string, body: ShippingAddressCreate): Promise<ShippingAddress>;
@@ -5651,8 +5653,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param shippingAddressId - Shipping Address ID.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} shippingAddressId - Shipping Address ID.
    * @return {Promise<ShippingAddress>} A shipping address.
    */
   getShippingAddress(accountId: string, shippingAddressId: string): Promise<ShippingAddress>;
@@ -5681,9 +5683,9 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param shippingAddressId - Shipping Address ID.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressUpdate}
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} shippingAddressId - Shipping Address ID.
+   * @param {ShippingAddressUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingAddressUpdate}
    * @return {Promise<ShippingAddress>} The updated shipping address.
    */
   updateShippingAddress(accountId: string, shippingAddressId: string, body: ShippingAddressUpdate): Promise<ShippingAddress>;
@@ -5708,8 +5710,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param shippingAddressId - Shipping Address ID.
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {string} shippingAddressId - Shipping Address ID.
    * @return {Promise<Empty>} Shipping address deleted.
    */
   removeShippingAddress(accountId: string, shippingAddressId: string): Promise<Empty>;
@@ -5725,9 +5727,9 @@ export declare class Client {
    *   console.log(subscription.uuid)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5739,19 +5741,19 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    *   
    *   - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
    *   - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
@@ -5759,7 +5761,7 @@ export declare class Client {
    *   
    * @return {Pager<Subscription>} A list of the account's subscriptions.
    */
-  listAccountSubscriptions(accountId: string, params?: object): Pager<Subscription>;
+  listAccountSubscriptions(accountId: string, options?: object): Pager<Subscription>;
   /**
    * List an account's transactions
    *
@@ -5772,9 +5774,9 @@ export declare class Client {
    *   console.log(transaction.uuid)
    * }
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5786,32 +5788,32 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-   * @param params.success - Filter by success field.
+   * @param {string} options.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+   * @param {string} options.success - Filter by success field.
    * @return {Pager<Transaction>} A list of the account's transactions.
    */
-  listAccountTransactions(accountId: string, params?: object): Pager<Transaction>;
+  listAccountTransactions(accountId: string, options?: object): Pager<Transaction>;
   /**
    * List an account's child accounts
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/list_child_accounts
    *
    * 
-   * @param accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5823,26 +5825,26 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-   * @param params.subscriber - Filter for accounts with or without a subscription in the `active`,
+   * @param {string} options.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+   * @param {boolean} options.subscriber - Filter for accounts with or without a subscription in the `active`,
    *   `canceled`, or `future` state.
    *   
-   * @param params.pastDue - Filter for accounts with an invoice in the `past_due` state.
+   * @param {string} options.pastDue - Filter for accounts with an invoice in the `past_due` state.
    * @return {Pager<Account>} A list of an account's child accounts.
    */
-  listChildAccounts(accountId: string, params?: object): Pager<Account>;
+  listChildAccounts(accountId: string, options?: object): Pager<Account>;
   /**
    * List a site's account acquisition data
    *
@@ -5855,8 +5857,8 @@ export declare class Client {
    *   console.log(acquisition.id)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5868,21 +5870,21 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<AccountAcquisition>} A list of the site's account acquisition data.
    */
-  listAccountAcquisition(params?: object): Pager<AccountAcquisition>;
+  listAccountAcquisition(options?: object): Pager<AccountAcquisition>;
   /**
    * List a site's coupons
    *
@@ -5895,8 +5897,8 @@ export declare class Client {
    *   console.log(coupon.code)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -5908,21 +5910,21 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<Coupon>} A list of the site's coupons.
    */
-  listCoupons(params?: object): Pager<Coupon>;
+  listCoupons(options?: object): Pager<Coupon>;
   /**
    * Create a new coupon
    *
@@ -5950,7 +5952,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponCreate}
+   * @param {CouponCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponCreate}
    * @return {Promise<Coupon>} A new coupon.
    */
   createCoupon(body: CouponCreate): Promise<Coupon>;
@@ -5975,7 +5977,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+   * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
    * @return {Promise<Coupon>} A coupon.
    */
   getCoupon(couponId: string): Promise<Coupon>;
@@ -6003,8 +6005,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
+   * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+   * @param {CouponUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
    * @return {Promise<Coupon>} The updated coupon.
    */
   updateCoupon(couponId: string, body: CouponUpdate): Promise<Coupon>;
@@ -6029,7 +6031,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+   * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
    * @return {Promise<Coupon>} The expired Coupon
    */
   deactivateCoupon(couponId: string): Promise<Coupon>;
@@ -6039,8 +6041,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/restore_coupon
    *
    * 
-   * @param couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
+   * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+   * @param {CouponUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {CouponUpdate}
    * @return {Promise<Coupon>} The restored coupon.
    */
   restoreCoupon(couponId: string, body: CouponUpdate): Promise<Coupon>;
@@ -6050,9 +6052,9 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/list_unique_coupon_codes
    *
    * 
-   * @param couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6064,21 +6066,21 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<UniqueCouponCode>} A list of unique coupon codes that were generated
    */
-  listUniqueCouponCodes(couponId: string, params?: object): Pager<UniqueCouponCode>;
+  listUniqueCouponCodes(couponId: string, options?: object): Pager<UniqueCouponCode>;
   /**
    * List a site's credit payments
    *
@@ -6091,29 +6093,29 @@ export declare class Client {
    *   console.log(payment.uuid)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<CreditPayment>} A list of the site's credit payments.
    */
-  listCreditPayments(params?: object): Pager<CreditPayment>;
+  listCreditPayments(options?: object): Pager<CreditPayment>;
   /**
    * Fetch a credit payment
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_credit_payment
    *
    * 
-   * @param creditPaymentId - Credit Payment ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} creditPaymentId - Credit Payment ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<CreditPayment>} A credit payment.
    */
   getCreditPayment(creditPaymentId: string): Promise<CreditPayment>;
@@ -6129,8 +6131,8 @@ export declare class Client {
    *   console.log(definition.displayName)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6142,22 +6144,22 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.relatedType - Filter by related type.
+   * @param {string} options.relatedType - Filter by related type.
    * @return {Pager<CustomFieldDefinition>} A list of the site's custom field definitions.
    */
-  listCustomFieldDefinitions(params?: object): Pager<CustomFieldDefinition>;
+  listCustomFieldDefinitions(options?: object): Pager<CustomFieldDefinition>;
   /**
    * Fetch an custom field definition
    *
@@ -6179,7 +6181,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param customFieldDefinitionId - Custom Field Definition ID
+   * @param {string} customFieldDefinitionId - Custom Field Definition ID
    * @return {Promise<CustomFieldDefinition>} An custom field definition.
    */
   getCustomFieldDefinition(customFieldDefinitionId: string): Promise<CustomFieldDefinition>;
@@ -6195,8 +6197,8 @@ export declare class Client {
    *   console.log(item.code)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6208,22 +6210,22 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<Item>} A list of the site's items.
    */
-  listItems(params?: object): Pager<Item>;
+  listItems(options?: object): Pager<Item>;
   /**
    * Create a new item
    *
@@ -6257,7 +6259,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemCreate}
+   * @param {ItemCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemCreate}
    * @return {Promise<Item>} A new item.
    */
   createItem(body: ItemCreate): Promise<Item>;
@@ -6282,7 +6284,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+   * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
   getItem(itemId: string): Promise<Item>;
@@ -6311,8 +6313,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemUpdate}
+   * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+   * @param {ItemUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ItemUpdate}
    * @return {Promise<Item>} The updated item.
    */
   updateItem(itemId: string, body: ItemUpdate): Promise<Item>;
@@ -6336,7 +6338,7 @@ export declare class Client {
    *   throw err
    * }
    * 
-   * @param itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+   * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
   deactivateItem(itemId: string): Promise<Item>;
@@ -6360,7 +6362,7 @@ export declare class Client {
    *   throw err
    * }
    * 
-   * @param itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
+   * @param {string} itemId - Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
    * @return {Promise<Item>} An item.
    */
   reactivateItem(itemId: string): Promise<Item>;
@@ -6370,8 +6372,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/list_measured_unit
    *
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6383,29 +6385,29 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<MeasuredUnit>} A list of the site's measured units.
    */
-  listMeasuredUnit(params?: object): Pager<MeasuredUnit>;
+  listMeasuredUnit(options?: object): Pager<MeasuredUnit>;
   /**
    * Create a new measured unit
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/create_measured_unit
    *
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {MeasuredUnitCreate}
+   * @param {MeasuredUnitCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {MeasuredUnitCreate}
    * @return {Promise<MeasuredUnit>} A new measured unit.
    */
   createMeasuredUnit(body: MeasuredUnitCreate): Promise<MeasuredUnit>;
@@ -6415,7 +6417,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_measured_unit
    *
    * 
-   * @param measuredUnitId - Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
+   * @param {string} measuredUnitId - Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
    * @return {Promise<MeasuredUnit>} An item.
    */
   getMeasuredUnit(measuredUnitId: string): Promise<MeasuredUnit>;
@@ -6425,8 +6427,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/update_measured_unit
    *
    * 
-   * @param measuredUnitId - Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {MeasuredUnitUpdate}
+   * @param {string} measuredUnitId - Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
+   * @param {MeasuredUnitUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {MeasuredUnitUpdate}
    * @return {Promise<MeasuredUnit>} The updated measured_unit.
    */
   updateMeasuredUnit(measuredUnitId: string, body: MeasuredUnitUpdate): Promise<MeasuredUnit>;
@@ -6436,7 +6438,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/remove_measured_unit
    *
    * 
-   * @param measuredUnitId - Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
+   * @param {string} measuredUnitId - Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
    * @return {Promise<MeasuredUnit>} A measured unit.
    */
   removeMeasuredUnit(measuredUnitId: string): Promise<MeasuredUnit>;
@@ -6452,8 +6454,8 @@ export declare class Client {
    *   console.log(invoice.number)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6465,19 +6467,19 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.type - Filter by type when:
+   * @param {string} options.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -6485,7 +6487,7 @@ export declare class Client {
    *   
    * @return {Pager<Invoice>} A list of the site's invoices.
    */
-  listInvoices(params?: object): Pager<Invoice>;
+  listInvoices(options?: object): Pager<Invoice>;
   /**
    * Fetch an invoice
    *
@@ -6507,7 +6509,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} An invoice.
    */
   getInvoice(invoiceId: string): Promise<Invoice>;
@@ -6538,8 +6540,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceUpdatable}
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {InvoiceUpdatable} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceUpdatable}
    * @return {Promise<Invoice>} An invoice.
    */
   putInvoice(invoiceId: string, body: InvoiceUpdatable): Promise<Invoice>;
@@ -6572,7 +6574,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<BinaryFile>} An invoice as a PDF.
    */
   getInvoicePdf(invoiceId: string): Promise<BinaryFile>;
@@ -6597,12 +6599,12 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {InvoiceCollect} options.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
    * @return {Promise<Invoice>} The updated invoice.
    */
-  collectInvoice(invoiceId: string, params?: object): Promise<Invoice>;
+  collectInvoice(invoiceId: string, options?: object): Promise<Invoice>;
   /**
    * Mark an open invoice as failed
    *
@@ -6624,7 +6626,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
   failInvoice(invoiceId: string): Promise<Invoice>;
@@ -6650,7 +6652,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
   markInvoiceSuccessful(invoiceId: string): Promise<Invoice>;
@@ -6675,7 +6677,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
   reopenInvoice(invoiceId: string): Promise<Invoice>;
@@ -6700,7 +6702,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Promise<Invoice>} The updated invoice.
    */
   voidInvoice(invoiceId: string): Promise<Invoice>;
@@ -6730,8 +6732,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ExternalTransaction}
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {ExternalTransaction} body - The object representing the JSON request to send to the server. It should conform to the schema of {ExternalTransaction}
    * @return {Promise<Transaction>} The recorded transaction.
    */
   recordExternalTransaction(invoiceId: string, body: ExternalTransaction): Promise<Transaction>;
@@ -6747,9 +6749,9 @@ export declare class Client {
    *   console.log(lineItem.id)
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6761,24 +6763,24 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.original - Filter by original field.
-   * @param params.state - Filter by state field.
-   * @param params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the invoice's line items.
    */
-  listInvoiceLineItems(invoiceId: string, params?: object): Pager<LineItem>;
+  listInvoiceLineItems(invoiceId: string, options?: object): Pager<LineItem>;
   /**
    * Show the coupon redemptions applied to an invoice
    *
@@ -6791,9 +6793,9 @@ export declare class Client {
    *   console.log(redemption.id)
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6805,19 +6807,19 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions associated with the invoice.
    */
-  listInvoiceCouponRedemptions(invoiceId: string, params?: object): Pager<CouponRedemption>;
+  listInvoiceCouponRedemptions(invoiceId: string, options?: object): Pager<CouponRedemption>;
   /**
    * List an invoice's related credit or charge invoices
    *
@@ -6830,10 +6832,10 @@ export declare class Client {
    *   console.log(invoice.number)
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
    * @return {Pager<Invoice>} A list of the credit or charge invoices associated with the invoice.
    */
-  listRelatedInvoices(invoiceId: string, params?: object): Pager<Invoice>;
+  listRelatedInvoices(invoiceId: string, options?: object): Pager<Invoice>;
   /**
    * Refund an invoice
    *
@@ -6862,8 +6864,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceRefund}
+   * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+   * @param {InvoiceRefund} body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceRefund}
    * @return {Promise<Invoice>} Returns the new credit invoice.
    */
   refundInvoice(invoiceId: string, body: InvoiceRefund): Promise<Invoice>;
@@ -6879,8 +6881,8 @@ export declare class Client {
    *   console.log(`Item ${item.id} for ${item.amount}`)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6892,24 +6894,24 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.original - Filter by original field.
-   * @param params.state - Filter by state field.
-   * @param params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the site's line items.
    */
-  listLineItems(params?: object): Pager<LineItem>;
+  listLineItems(options?: object): Pager<LineItem>;
   /**
    * Fetch a line item
    *
@@ -6931,7 +6933,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param lineItemId - Line Item ID.
+   * @param {string} lineItemId - Line Item ID.
    * @return {Promise<LineItem>} A line item.
    */
   getLineItem(lineItemId: string): Promise<LineItem>;
@@ -6956,7 +6958,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param lineItemId - Line Item ID.
+   * @param {string} lineItemId - Line Item ID.
    * @return {Promise<Empty>} Line item deleted.
    */
   removeLineItem(lineItemId: string): Promise<Empty>;
@@ -6972,8 +6974,8 @@ export declare class Client {
    *   console.log(plan.code)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -6985,22 +6987,22 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<Plan>} A list of plans.
    */
-  listPlans(params?: object): Pager<Plan>;
+  listPlans(options?: object): Pager<Plan>;
   /**
    * Create a plan
    *
@@ -7032,7 +7034,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanCreate}
+   * @param {PlanCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanCreate}
    * @return {Promise<Plan>} A plan.
    */
   createPlan(body: PlanCreate): Promise<Plan>;
@@ -7057,7 +7059,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<Plan>} A plan.
    */
   getPlan(planId: string): Promise<Plan>;
@@ -7085,8 +7087,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanUpdate}
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {PlanUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PlanUpdate}
    * @return {Promise<Plan>} A plan.
    */
   updatePlan(planId: string, body: PlanUpdate): Promise<Plan>;
@@ -7111,7 +7113,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<Plan>} Plan deleted
    */
   removePlan(planId: string): Promise<Plan>;
@@ -7127,9 +7129,9 @@ export declare class Client {
    *   console.log(addOn.code)
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7141,22 +7143,22 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<AddOn>} A list of add-ons.
    */
-  listPlanAddOns(planId: string, params?: object): Pager<AddOn>;
+  listPlanAddOns(planId: string, options?: object): Pager<AddOn>;
   /**
    * Create an add-on
    *
@@ -7190,8 +7192,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnCreate}
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {AddOnCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnCreate}
    * @return {Promise<AddOn>} An add-on.
    */
   createPlanAddOn(planId: string, body: AddOnCreate): Promise<AddOn>;
@@ -7216,8 +7218,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} An add-on.
    */
   getPlanAddOn(planId: string, addOnId: string): Promise<AddOn>;
@@ -7245,9 +7247,9 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnUpdate}
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {AddOnUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {AddOnUpdate}
    * @return {Promise<AddOn>} An add-on.
    */
   updatePlanAddOn(planId: string, addOnId: string, body: AddOnUpdate): Promise<AddOn>;
@@ -7272,8 +7274,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} Add-on deleted
    */
   removePlanAddOn(planId: string, addOnId: string): Promise<AddOn>;
@@ -7289,8 +7291,8 @@ export declare class Client {
    *   console.log(addOn.code)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7302,22 +7304,22 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<AddOn>} A list of add-ons.
    */
-  listAddOns(params?: object): Pager<AddOn>;
+  listAddOns(options?: object): Pager<AddOn>;
   /**
    * Fetch an add-on
    *
@@ -7339,7 +7341,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
    * @return {Promise<AddOn>} An add-on.
    */
   getAddOn(addOnId: string): Promise<AddOn>;
@@ -7355,8 +7357,8 @@ export declare class Client {
    *   console.log(method.code)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7368,28 +7370,28 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<ShippingMethod>} A list of the site's shipping methods.
    */
-  listShippingMethods(params?: object): Pager<ShippingMethod>;
+  listShippingMethods(options?: object): Pager<ShippingMethod>;
   /**
    * Create a new shipping method
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/create_shipping_method
    *
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodCreate}
+   * @param {ShippingMethodCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodCreate}
    * @return {Promise<ShippingMethod>} A new shipping method.
    */
   createShippingMethod(body: ShippingMethodCreate): Promise<ShippingMethod>;
@@ -7399,7 +7401,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_shipping_method
    *
    * 
-   * @param id - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
+   * @param {string} id - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
    * @return {Promise<ShippingMethod>} A shipping method.
    */
   getShippingMethod(id: string): Promise<ShippingMethod>;
@@ -7409,8 +7411,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/update_shipping_method
    *
    * 
-   * @param shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodUpdate}
+   * @param {string} shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
+   * @param {ShippingMethodUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {ShippingMethodUpdate}
    * @return {Promise<ShippingMethod>} The updated shipping method.
    */
   updateShippingMethod(shippingMethodId: string, body: ShippingMethodUpdate): Promise<ShippingMethod>;
@@ -7420,7 +7422,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_shipping_method
    *
    * 
-   * @param shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
+   * @param {string} shippingMethodId - Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
    * @return {Promise<ShippingMethod>} A shipping method.
    */
   deactivateShippingMethod(shippingMethodId: string): Promise<ShippingMethod>;
@@ -7436,8 +7438,8 @@ export declare class Client {
    *   console.log(subscription.uuid)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7449,19 +7451,19 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    *   
    *   - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
    *   - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
@@ -7469,7 +7471,7 @@ export declare class Client {
    *   
    * @return {Pager<Subscription>} A list of the site's subscriptions.
    */
-  listSubscriptions(params?: object): Pager<Subscription>;
+  listSubscriptions(options?: object): Pager<Subscription>;
   /**
    * Create a new subscription
    *
@@ -7498,7 +7500,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCreate}
+   * @param {SubscriptionCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCreate}
    * @return {Promise<Subscription>} A subscription.
    */
   createSubscription(body: SubscriptionCreate): Promise<Subscription>;
@@ -7523,7 +7525,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
   getSubscription(subscriptionId: string): Promise<Subscription>;
@@ -7553,8 +7555,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionUpdate}
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {SubscriptionUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionUpdate}
    * @return {Promise<Subscription>} A subscription.
    */
   modifySubscription(subscriptionId: string, body: SubscriptionUpdate): Promise<Subscription>;
@@ -7579,9 +7581,9 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.refund - The type of refund to perform:
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string} options.refund - The type of refund to perform:
    *   
    *   * `full` - Performs a full refund of the last invoice for the current subscription term.
    *   * `partial` - Prorates a refund based on the amount of time remaining in the current bill cycle.
@@ -7591,9 +7593,10 @@ export declare class Client {
    *   
    *   You may also terminate a subscription with no refund and then manually refund specific invoices.
    *   
+   * @param {boolean} options.charge - Applicable only if the subscription has usage based add-ons and unbilled usage logged for the current billing cycle. If true, current billing cycle unbilled usage is billed on the final invoice. If false, Recurly will create a negative usage record for current billing cycle usage that will zero out the final invoice line items.
    * @return {Promise<Subscription>} An expired subscription.
    */
-  terminateSubscription(subscriptionId: string, params?: object): Promise<Subscription>;
+  terminateSubscription(subscriptionId: string, options?: object): Promise<Subscription>;
   /**
    * Cancel a subscription
    *
@@ -7615,12 +7618,12 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {SubscriptionCancel} options.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
    * @return {Promise<Subscription>} A canceled or failed subscription.
    */
-  cancelSubscription(subscriptionId: string, params?: object): Promise<Subscription>;
+  cancelSubscription(subscriptionId: string, options?: object): Promise<Subscription>;
   /**
    * Reactivate a canceled subscription
    *
@@ -7643,7 +7646,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} An active subscription.
    */
   reactivateSubscription(subscriptionId: string): Promise<Subscription>;
@@ -7671,8 +7674,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionPause}
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {SubscriptionPause} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionPause}
    * @return {Promise<Subscription>} A subscription.
    */
   pauseSubscription(subscriptionId: string, body: SubscriptionPause): Promise<Subscription>;
@@ -7697,7 +7700,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
   resumeSubscription(subscriptionId: string): Promise<Subscription>;
@@ -7707,7 +7710,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/convert_trial
    *
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Subscription>} A subscription.
    */
   convertTrial(subscriptionId: string): Promise<Subscription>;
@@ -7732,7 +7735,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<SubscriptionChange>} A subscription's pending change.
    */
   getSubscriptionChange(subscriptionId: string): Promise<SubscriptionChange>;
@@ -7762,8 +7765,8 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {SubscriptionChangeCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChange>} A subscription change.
    */
   createSubscriptionChange(subscriptionId: string, body: SubscriptionChangeCreate): Promise<SubscriptionChange>;
@@ -7788,7 +7791,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Empty>} Subscription change was deleted.
    */
   removeSubscriptionChange(subscriptionId: string): Promise<Empty>;
@@ -7798,8 +7801,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/preview_subscription_change
    *
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {SubscriptionChangeCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionChangeCreate}
    * @return {Promise<SubscriptionChangePreview>} A subscription change.
    */
   previewSubscriptionChange(subscriptionId: string, body: SubscriptionChangeCreate): Promise<SubscriptionChangePreview>;
@@ -7815,9 +7818,9 @@ export declare class Client {
    *   console.log(invoice.number)
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7829,19 +7832,19 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.type - Filter by type when:
+   * @param {string} options.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -7849,7 +7852,7 @@ export declare class Client {
    *   
    * @return {Pager<Invoice>} A list of the subscription's invoices.
    */
-  listSubscriptionInvoices(subscriptionId: string, params?: object): Pager<Invoice>;
+  listSubscriptionInvoices(subscriptionId: string, options?: object): Pager<Invoice>;
   /**
    * List a subscription's line items
    *
@@ -7862,9 +7865,9 @@ export declare class Client {
    *   console.log(lineItem.id)
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7876,24 +7879,24 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.original - Filter by original field.
-   * @param params.state - Filter by state field.
-   * @param params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the subscription's line items.
    */
-  listSubscriptionLineItems(subscriptionId: string, params?: object): Pager<LineItem>;
+  listSubscriptionLineItems(subscriptionId: string, options?: object): Pager<LineItem>;
   /**
    * Show the coupon redemptions for a subscription
    *
@@ -7906,9 +7909,9 @@ export declare class Client {
    *   console.log(redemption.id)
    * }
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7920,29 +7923,29 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on a subscription.
    */
-  listSubscriptionCouponRedemptions(subscriptionId: string, params?: object): Pager<CouponRedemption>;
+  listSubscriptionCouponRedemptions(subscriptionId: string, options?: object): Pager<CouponRedemption>;
   /**
    * List a subscription add-on's usage records
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/list_usage
    *
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -7954,31 +7957,31 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `usage_timestamp` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `usage_timestamp` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.billingStatus - Filter by usage record's billing status
+   * @param {string} options.billingStatus - Filter by usage record's billing status
    * @return {Pager<Usage>} A list of the subscription add-on's usage records.
    */
-  listUsage(subscriptionId: string, addOnId: string, params?: object): Pager<Usage>;
+  listUsage(subscriptionId: string, addOnId: string, options?: object): Pager<Usage>;
   /**
    * Log a usage record on this subscription add-on
    *
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/create_usage
    *
    * 
-   * @param subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {UsageCreate}
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
+   * @param {UsageCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {UsageCreate}
    * @return {Promise<Usage>} The created usage record.
    */
   createUsage(subscriptionId: string, addOnId: string, body: UsageCreate): Promise<Usage>;
@@ -7988,7 +7991,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_usage
    *
    * 
-   * @param usageId - Usage Record ID.
+   * @param {string} usageId - Usage Record ID.
    * @return {Promise<Usage>} The usage record.
    */
   getUsage(usageId: string): Promise<Usage>;
@@ -7998,8 +8001,8 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/update_usage
    *
    * 
-   * @param usageId - Usage Record ID.
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {UsageCreate}
+   * @param {string} usageId - Usage Record ID.
+   * @param {UsageCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {UsageCreate}
    * @return {Promise<Usage>} The updated usage record.
    */
   updateUsage(usageId: string, body: UsageCreate): Promise<Usage>;
@@ -8009,7 +8012,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/remove_usage
    *
    * 
-   * @param usageId - Usage Record ID.
+   * @param {string} usageId - Usage Record ID.
    * @return {Promise<Empty>} Usage was successfully deleted.
    */
   removeUsage(usageId: string): Promise<Empty>;
@@ -8025,8 +8028,8 @@ export declare class Client {
    *   console.log(transaction.uuid)
    * }
    * 
-   * @param {Object} params - The optional url parameters for this request.
-   * @param params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string[]} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *   
    *   **Important notes:**
@@ -8038,23 +8041,23 @@ export declare class Client {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *   
-   * @param params.limit - Limit number of records 1-200.
-   * @param params.order - Sort order.
-   * @param params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *   
-   * @param params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *   
-   * @param params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-   * @param params.success - Filter by success field.
+   * @param {string} options.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+   * @param {string} options.success - Filter by success field.
    * @return {Pager<Transaction>} A list of the site's transactions.
    */
-  listTransactions(params?: object): Pager<Transaction>;
+  listTransactions(options?: object): Pager<Transaction>;
   /**
    * Fetch a transaction
    *
@@ -8076,7 +8079,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param transactionId - Transaction ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @param {string} transactionId - Transaction ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<Transaction>} A transaction.
    */
   getTransaction(transactionId: string): Promise<Transaction>;
@@ -8086,7 +8089,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_unique_coupon_code
    *
    * 
-   * @param uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
+   * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
   getUniqueCouponCode(uniqueCouponCodeId: string): Promise<UniqueCouponCode>;
@@ -8096,7 +8099,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_unique_coupon_code
    *
    * 
-   * @param uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
+   * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
   deactivateUniqueCouponCode(uniqueCouponCodeId: string): Promise<UniqueCouponCode>;
@@ -8106,7 +8109,7 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_unique_coupon_code
    *
    * 
-   * @param uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
+   * @param {string} uniqueCouponCodeId - Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
    * @return {Promise<UniqueCouponCode>} A unique coupon code.
    */
   reactivateUniqueCouponCode(uniqueCouponCodeId: string): Promise<UniqueCouponCode>;
@@ -8146,7 +8149,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
+   * @param {PurchaseCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns the new invoices
    */
   createPurchase(body: PurchaseCreate): Promise<InvoiceCollection>;
@@ -8186,7 +8189,7 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
+   * @param {PurchaseCreate} body - The object representing the JSON request to send to the server. It should conform to the schema of {PurchaseCreate}
    * @return {Promise<InvoiceCollection>} Returns preview of the new invoices
    */
   previewPurchase(body: PurchaseCreate): Promise<InvoiceCollection>;
@@ -8227,107 +8230,66 @@ export declare class Client {
    *   }
    * }
    * 
-   * @param exportDate - Date for which to get a list of available automated export files. Date must be in YYYY-MM-DD format.
+   * @param {string} exportDate - Date for which to get a list of available automated export files. Date must be in YYYY-MM-DD format.
    * @return {Promise<ExportFiles>} Returns a list of export files to download.
    */
   getExportFiles(exportDate: string): Promise<ExportFiles>;
 
 }
 
-export class ApiError {
+export class ApiError extends Error {
   constructor (message: string, type: string, attributes: any);
   getResponse: () => Response;
-
-  /**
-   * @private
-   */
-  _setResponse: (response: Response) => void;
 }
 
-export class ResponseError extends ApiError { }
-export class ServerError extends ResponseError { }
-export class InternalServerError extends ServerError { }
-export class ServiceNotAvailableError extends InternalServerError { }
-export class BadGatewayError extends ServerError { }
-export class ServiceUnavailableError extends ServerError { }
-export class TimeoutError extends ServerError { }
-export class RedirectionError extends ResponseError { }
-export class NotModifiedError extends ResponseError { }
-export class ClientError extends ApiError { }
-export class BadRequestError extends ClientError { }
-export class InvalidContentTypeError extends BadRequestError { }
-export class UnauthorizedError extends ClientError { }
-export class PaymentRequiredError extends ClientError { }
-export class ForbiddenError extends ClientError { }
-export class InvalidApiKeyError extends ForbiddenError { }
-export class InvalidPermissionsError extends ForbiddenError { }
-export class NotFoundError extends ClientError { }
-export class NotAcceptableError extends ClientError { }
-export class UnknownApiVersionError extends NotAcceptableError { }
-export class UnavailableInApiVersionError extends NotAcceptableError { }
-export class InvalidApiVersionError extends NotAcceptableError { }
-export class PreconditionFailedError extends ClientError { }
-export class UnprocessableEntityError extends ClientError { }
-export class ValidationError extends UnprocessableEntityError { }
-export class MissingFeatureError extends UnprocessableEntityError { }
-export class TransactionError extends UnprocessableEntityError { }
-export class SimultaneousRequestError extends UnprocessableEntityError { }
-export class ImmutableSubscriptionError extends UnprocessableEntityError { }
-export class InvalidTokenError extends UnprocessableEntityError { }
-export class TooManyRequestsError extends ClientError { }
-export class RateLimitedError extends TooManyRequestsError { }
+declare namespace errors {
+  export class ResponseError extends ApiError { }
+  export class ServerError extends ResponseError { }
+  export class InternalServerError extends ServerError { }
+  export class ServiceNotAvailableError extends InternalServerError { }
+  export class BadGatewayError extends ServerError { }
+  export class ServiceUnavailableError extends ServerError { }
+  export class TimeoutError extends ServerError { }
+  export class RedirectionError extends ResponseError { }
+  export class NotModifiedError extends ResponseError { }
+  export class ClientError extends ApiError { }
+  export class BadRequestError extends ClientError { }
+  export class InvalidContentTypeError extends BadRequestError { }
+  export class UnauthorizedError extends ClientError { }
+  export class PaymentRequiredError extends ClientError { }
+  export class ForbiddenError extends ClientError { }
+  export class InvalidApiKeyError extends ForbiddenError { }
+  export class InvalidPermissionsError extends ForbiddenError { }
+  export class NotFoundError extends ClientError { }
+  export class NotAcceptableError extends ClientError { }
+  export class UnknownApiVersionError extends NotAcceptableError { }
+  export class UnavailableInApiVersionError extends NotAcceptableError { }
+  export class InvalidApiVersionError extends NotAcceptableError { }
+  export class PreconditionFailedError extends ClientError { }
+  export class UnprocessableEntityError extends ClientError { }
+  export class ValidationError extends UnprocessableEntityError { }
+  export class MissingFeatureError extends UnprocessableEntityError { }
+  export class TransactionError extends UnprocessableEntityError { }
+  export class SimultaneousRequestError extends UnprocessableEntityError { }
+  export class ImmutableSubscriptionError extends UnprocessableEntityError { }
+  export class InvalidTokenError extends UnprocessableEntityError { }
+  export class TooManyRequestsError extends ClientError { }
+  export class RateLimitedError extends TooManyRequestsError { }
 
-export interface ErrorMap {
-  500: InternalServerError;
-  502: BadGatewayError;
-  503: ServiceUnavailableError;
-  504: TimeoutError;
-  304: NotModifiedError;
-  400: BadRequestError;
-  401: UnauthorizedError;
-  402: PaymentRequiredError;
-  403: ForbiddenError;
-  404: NotFoundError;
-  406: NotAcceptableError;
-  412: PreconditionFailedError;
-  422: UnprocessableEntityError;
-  429: TooManyRequestsError;
+  export const ERROR_MAP: {
+    500: InternalServerError;
+    502: BadGatewayError;
+    503: ServiceUnavailableError;
+    504: TimeoutError;
+    304: NotModifiedError;
+    400: BadRequestError;
+    401: UnauthorizedError;
+    402: PaymentRequiredError;
+    403: ForbiddenError;
+    404: NotFoundError;
+    406: NotAcceptableError;
+    412: PreconditionFailedError;
+    422: UnprocessableEntityError;
+    429: TooManyRequestsError;
+  };
 }
-
-export interface Errors {
-  ERROR_MAP: ErrorMap;
-  ResponseError: ResponseError;
-  ServerError: ServerError;
-  InternalServerError: InternalServerError;
-  ServiceNotAvailableError: ServiceNotAvailableError;
-  BadGatewayError: BadGatewayError;
-  ServiceUnavailableError: ServiceUnavailableError;
-  TimeoutError: TimeoutError;
-  RedirectionError: RedirectionError;
-  NotModifiedError: NotModifiedError;
-  ClientError: ClientError;
-  BadRequestError: BadRequestError;
-  InvalidContentTypeError: InvalidContentTypeError;
-  UnauthorizedError: UnauthorizedError;
-  PaymentRequiredError: PaymentRequiredError;
-  ForbiddenError: ForbiddenError;
-  InvalidApiKeyError: InvalidApiKeyError;
-  InvalidPermissionsError: InvalidPermissionsError;
-  NotFoundError: NotFoundError;
-  NotAcceptableError: NotAcceptableError;
-  UnknownApiVersionError: UnknownApiVersionError;
-  UnavailableInApiVersionError: UnavailableInApiVersionError;
-  InvalidApiVersionError: InvalidApiVersionError;
-  PreconditionFailedError: PreconditionFailedError;
-  UnprocessableEntityError: UnprocessableEntityError;
-  ValidationError: ValidationError;
-  MissingFeatureError: MissingFeatureError;
-  TransactionError: TransactionError;
-  SimultaneousRequestError: SimultaneousRequestError;
-  ImmutableSubscriptionError: ImmutableSubscriptionError;
-  InvalidTokenError: InvalidTokenError;
-  TooManyRequestsError: TooManyRequestsError;
-  RateLimitedError: RateLimitedError;
-}
-
-export const errors: Errors

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -32,9 +32,8 @@ class Client extends BaseClient {
    *   console.log(site.subdomain)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -46,13 +45,13 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<Site>} A list of sites.
    */
   listSites (options = {}) {
@@ -103,9 +102,8 @@ class Client extends BaseClient {
    *   console.log(account.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -117,23 +115,23 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-   * @param {boolean} options.params.subscriber - Filter for accounts with or without a subscription in the `active`,
+   * @param {string} options.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+   * @param {boolean} options.subscriber - Filter for accounts with or without a subscription in the `active`,
    *   `canceled`, or `future` state.
    *
-   * @param {string} options.params.pastDue - Filter for accounts with an invoice in the `past_due` state.
+   * @param {string} options.pastDue - Filter for accounts with an invoice in the `past_due` state.
    * @return {Pager<Account>} A list of the site's accounts.
    */
   listAccounts (options = {}) {
@@ -535,9 +533,8 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -549,14 +546,14 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<BillingInfo>} A list of the the billing information for an account's
@@ -645,9 +642,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -659,16 +655,17 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
+   * @param {string} options.state - Filter by state.
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on an account.
    */
   listAccountCouponRedemptions (accountId, options = {}) {
@@ -766,18 +763,17 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CreditPayment>} A list of the account's credit payments.
@@ -801,9 +797,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -815,19 +810,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.type - Filter by type when:
+   * @param {string} options.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -928,9 +923,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -942,21 +936,21 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.original - Filter by original field.
-   * @param {string} options.params.state - Filter by state field.
-   * @param {string} options.params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the account's line items.
    */
   listAccountLineItems (accountId, options = {}) {
@@ -1014,9 +1008,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1081,9 +1074,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1095,16 +1087,16 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<ShippingAddress>} A list of an account's shipping addresses.
@@ -1266,9 +1258,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1280,19 +1271,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    *
    *   - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
    *   - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
@@ -1319,9 +1310,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1333,20 +1323,20 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-   * @param {string} options.params.success - Filter by success field.
+   * @param {string} options.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+   * @param {string} options.success - Filter by success field.
    * @return {Pager<Transaction>} A list of the account's transactions.
    */
   listAccountTransactions (accountId, options = {}) {
@@ -1362,9 +1352,8 @@ class Client extends BaseClient {
    *
    *
    * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1376,23 +1365,23 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-   * @param {boolean} options.params.subscriber - Filter for accounts with or without a subscription in the `active`,
+   * @param {string} options.email - Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
+   * @param {boolean} options.subscriber - Filter for accounts with or without a subscription in the `active`,
    *   `canceled`, or `future` state.
    *
-   * @param {string} options.params.pastDue - Filter for accounts with an invoice in the `past_due` state.
+   * @param {string} options.pastDue - Filter for accounts with an invoice in the `past_due` state.
    * @return {Pager<Account>} A list of an account's child accounts.
    */
   listChildAccounts (accountId, options = {}) {
@@ -1413,9 +1402,8 @@ class Client extends BaseClient {
    *   console.log(acquisition.id)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1427,16 +1415,16 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<AccountAcquisition>} A list of the site's account acquisition data.
@@ -1459,9 +1447,8 @@ class Client extends BaseClient {
    *   console.log(coupon.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1473,16 +1460,16 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<Coupon>} A list of the site's coupons.
@@ -1646,9 +1633,8 @@ class Client extends BaseClient {
    *
    *
    * @param {string} couponId - Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1660,16 +1646,16 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<UniqueCouponCode>} A list of unique coupon codes that were generated
@@ -1692,18 +1678,17 @@ class Client extends BaseClient {
    *   console.log(payment.uuid)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CreditPayment>} A list of the site's credit payments.
@@ -1741,9 +1726,8 @@ class Client extends BaseClient {
    *   console.log(definition.displayName)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1755,19 +1739,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.relatedType - Filter by related type.
+   * @param {string} options.relatedType - Filter by related type.
    * @return {Pager<CustomFieldDefinition>} A list of the site's custom field definitions.
    */
   listCustomFieldDefinitions (options = {}) {
@@ -1818,9 +1802,8 @@ class Client extends BaseClient {
    *   console.log(item.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -1832,19 +1815,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<Item>} A list of the site's items.
    */
   listItems (options = {}) {
@@ -2024,9 +2007,8 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/list_measured_unit}
    *
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2038,19 +2020,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<MeasuredUnit>} A list of the site's measured units.
    */
   listMeasuredUnit (options = {}) {
@@ -2132,9 +2114,8 @@ class Client extends BaseClient {
    *   console.log(invoice.number)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2146,19 +2127,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.type - Filter by type when:
+   * @param {string} options.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -2299,8 +2280,7 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Object} options - The optional url parameters for this request.
    * @param {InvoiceCollect} options.body - The object representing the JSON request to send to the server. It should conform to the schema of {InvoiceCollect}
    * @return {Promise<Invoice>} The updated invoice.
    */
@@ -2481,9 +2461,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2495,21 +2474,21 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.original - Filter by original field.
-   * @param {string} options.params.state - Filter by state field.
-   * @param {string} options.params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the invoice's line items.
    */
   listInvoiceLineItems (invoiceId, options = {}) {
@@ -2531,9 +2510,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} invoiceId - Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2545,14 +2523,14 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions associated with the invoice.
@@ -2634,9 +2612,8 @@ class Client extends BaseClient {
    *   console.log(`Item ${item.id} for ${item.amount}`)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2648,21 +2625,21 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.original - Filter by original field.
-   * @param {string} options.params.state - Filter by state field.
-   * @param {string} options.params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the site's line items.
    */
   listLineItems (options = {}) {
@@ -2743,9 +2720,8 @@ class Client extends BaseClient {
    *   console.log(plan.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2757,19 +2733,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<Plan>} A list of plans.
    */
   listPlans (options = {}) {
@@ -2925,9 +2901,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} planId - Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -2939,19 +2914,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<AddOn>} A list of add-ons.
    */
   listPlanAddOns (planId, options = {}) {
@@ -3112,9 +3087,8 @@ class Client extends BaseClient {
    *   console.log(addOn.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3126,19 +3100,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    * @return {Pager<AddOn>} A list of add-ons.
    */
   listAddOns (options = {}) {
@@ -3189,9 +3163,8 @@ class Client extends BaseClient {
    *   console.log(method.code)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3203,16 +3176,16 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<ShippingMethod>} A list of the site's shipping methods.
@@ -3296,9 +3269,8 @@ class Client extends BaseClient {
    *   console.log(subscription.uuid)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3310,19 +3282,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.state - Filter by state.
+   * @param {string} options.state - Filter by state.
    *
    *   - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
    *   - When `state=in_trial`, only subscriptions that have a trial_started_at date earlier than now and a trial_ends_at date later than now will be returned.
@@ -3461,9 +3433,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {string} options.params.refund - The type of refund to perform:
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {string} options.refund - The type of refund to perform:
    *
    *   * `full` - Performs a full refund of the last invoice for the current subscription term.
    *   * `partial` - Prorates a refund based on the amount of time remaining in the current bill cycle.
@@ -3473,6 +3444,7 @@ class Client extends BaseClient {
    *
    *   You may also terminate a subscription with no refund and then manually refund specific invoices.
    *
+   * @param {boolean} options.charge - Applicable only if the subscription has usage based add-ons and unbilled usage logged for the current billing cycle. If true, current billing cycle unbilled usage is billed on the final invoice. If false, Recurly will create a negative usage record for current billing cycle usage that will zero out the final invoice line items.
    * @return {Promise<Subscription>} An expired subscription.
    */
   async terminateSubscription (subscriptionId, options = {}) {
@@ -3503,8 +3475,7 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
+   * @param {Object} options - The optional url parameters for this request.
    * @param {SubscriptionCancel} options.body - The object representing the JSON request to send to the server. It should conform to the schema of {SubscriptionCancel}
    * @return {Promise<Subscription>} A canceled or failed subscription.
    */
@@ -3750,9 +3721,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3764,19 +3734,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.type - Filter by type when:
+   * @param {string} options.type - Filter by type when:
    *   - `type=charge`, only charge invoices will be returned.
    *   - `type=credit`, only credit invoices will be returned.
    *   - `type=non-legacy`, only charge and credit invoices will be returned.
@@ -3803,9 +3773,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3817,21 +3786,21 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.original - Filter by original field.
-   * @param {string} options.params.state - Filter by state field.
-   * @param {string} options.params.type - Filter by type field.
+   * @param {string} options.original - Filter by original field.
+   * @param {string} options.state - Filter by state field.
+   * @param {string} options.type - Filter by type field.
    * @return {Pager<LineItem>} A list of the subscription's line items.
    */
   listSubscriptionLineItems (subscriptionId, options = {}) {
@@ -3853,9 +3822,8 @@ class Client extends BaseClient {
    * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3867,14 +3835,14 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
    * @return {Pager<CouponRedemption>} A list of the the coupon redemptions on a subscription.
@@ -3893,9 +3861,8 @@ class Client extends BaseClient {
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @param {string} addOnId - Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -3907,19 +3874,19 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `usage_timestamp` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `usage_timestamp` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.billingStatus - Filter by usage record's billing status
+   * @param {string} options.billingStatus - Filter by usage record's billing status
    * @return {Pager<Usage>} A list of the subscription add-on's usage records.
    */
   listUsage (subscriptionId, addOnId, options = {}) {
@@ -4003,9 +3970,8 @@ class Client extends BaseClient {
    *   console.log(transaction.uuid)
    * }
    *
-   * @param {Object} options - Optional configurations for the request
-   * @param {Object} options.params - The optional url parameters for this request.
-   * @param {Array.<string>} options.params.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+   * @param {Object} options - The optional url parameters for this request.
+   * @param {Array.<string>} options.ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
    *   commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
    *
    *   **Important notes:**
@@ -4017,20 +3983,20 @@ class Client extends BaseClient {
    *   * Records are returned in an arbitrary order. Since results are all
    *     returned at once you can sort the records yourself.
    *
-   * @param {number} options.params.limit - Limit number of records 1-200.
-   * @param {string} options.params.order - Sort order.
-   * @param {string} options.params.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+   * @param {number} options.limit - Limit number of records 1-200.
+   * @param {string} options.order - Sort order.
+   * @param {string} options.sort - Sort field. You *really* only want to sort by `updated_at` in ascending
    *   order. In descending order updated records will move behind the cursor and could
    *   prevent some records from being returned.
    *
-   * @param {Date} options.params.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.beginTime - Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {Date} options.params.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
+   * @param {Date} options.endTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
    *   **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
    *
-   * @param {string} options.params.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-   * @param {string} options.params.success - Filter by success field.
+   * @param {string} options.type - Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
+   * @param {string} options.success - Filter by success field.
    * @return {Pager<Transaction>} A list of the site's transactions.
    */
   listTransactions (options = {}) {

--- a/lib/recurly/resources/Subscription.js
+++ b/lib/recurly/resources/Subscription.js
@@ -21,7 +21,7 @@ const Resource = require('../Resource')
  * @prop {string} billingInfoId - Billing Info ID.
  * @prop {Date} canceledAt - Canceled at
  * @prop {string} collectionMethod - Collection method
- * @prop {Array.<CouponRedemptionMini>} couponRedemptions - Coupon redemptions
+ * @prop {Array.<CouponRedemptionMini>} couponRedemptions - Returns subscription level coupon redemptions that are tied to this subscription.
  * @prop {Date} createdAt - Created at
  * @prop {string} currency - 3-letter ISO 4217 currency code.
  * @prop {Date} currentPeriodEndsAt - Current billing period ends at

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -10043,7 +10043,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.PricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2481,6 +2481,7 @@ paths:
       - "$ref": "#/components/parameters/sort_dates"
       - "$ref": "#/components/parameters/filter_begin_time"
       - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_state"
       responses:
         '200':
           description: A list of the the coupon redemptions on an account.
@@ -10042,7 +10043,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: []recurly.PricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
@@ -11451,6 +11452,16 @@ paths:
           - partial
           - none
           default: none
+      - name: charge
+        in: query
+        description: Applicable only if the subscription has usage based add-ons and
+          unbilled usage logged for the current billing cycle. If true, current billing
+          cycle unbilled usage is billed on the final invoice. If false, Recurly will
+          create a negative usage record for current billing cycle usage that will
+          zero out the final invoice line items.
+        schema:
+          default: true
+          type: boolean
       responses:
         '200':
           description: An expired subscription.
@@ -19310,6 +19321,8 @@ components:
         coupon_redemptions:
           type: array
           title: Coupon redemptions
+          description: Returns subscription level coupon redemptions that are tied
+            to this subscription.
           items:
             "$ref": "#/components/schemas/CouponRedemptionMini"
         pending_change:


### PR DESCRIPTION
- Adds the `state` parameter to the `listAccountCouponRedemptions` operation.
- Adds the `charge` parameter to the `terminateSubscription` operation so that a merchant can choose to not bill a customer for un-billed usage when terminating a subscription 