### PR TITLE
Fix types of count() and first() on Pager<T>

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -2666,8 +2666,8 @@ export interface Empty {
 }
 
 export declare class Pager<T> {
-  count(): number;
-  first(): T;
+  count(): Promise<number>;
+  first(): Promise<T>;
   each(): AsyncIterable<T>;
   eachPage(): AsyncIterable<T[]>;
 }


### PR DESCRIPTION
Fixes TypeScript definitions. These methods apparently return Promises.