### PR TITLE
Fix types of count() and first() on Pager<T>

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -2666,8 +2666,8 @@ export interface Empty {
 }
 
 export declare class Pager<T> {
-  count(): number;
-  first(): T;
+  count(): Promise<number>;
+  first(): Promise<T>;
   each(): AsyncIterable<T>;
   eachPage(): AsyncIterable<T[]>;
 }


### PR DESCRIPTION
Fixing the types of `count()` and `first()` on `Pager<T>` to be a `Promise` to match the existing behavior of the client.

This PR is a generated update from: https://github.com/recurly/recurly-client-node/pull/170