### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -2666,8 +2666,8 @@ export interface Empty {
 }
 
 export declare class Pager<T> {
-  count(): number;
-  first(): T;
+  count(): Promise<number>;
+  first(): Promise<T>;
   each(): AsyncIterable<T>;
   eachPage(): AsyncIterable<T[]>;
 }
@@ -4074,6 +4074,10 @@ export interface SubscriptionCreate {
   planId?: string | null;
   account?: AccountCreate | null;
   /**
+    * The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+    */
+  billingInfoId?: string | null;
+  /**
     * Create a shipping address on the account and assign it to the subscription.
     */
   shipping?: SubscriptionShippingCreate | null;
@@ -4448,6 +4452,10 @@ export interface PurchaseCreate {
     */
   currency?: string | null;
   account?: AccountPurchase | null;
+  /**
+    * The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+    */
+  billingInfoId?: string | null;
   /**
     * Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.
     */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15154,7 +15154,7 @@ components:
           maxLength: 255
         company:
           type: string
-          maxLength: 50
+          maxLength: 100
         vat_number:
           type: string
           description: The VAT number of the account (to avoid having the VAT applied).
@@ -20079,6 +20079,13 @@ components:
             are provided the `plan_id` will be used.
         account:
           "$ref": "#/components/schemas/AccountCreate"
+        billing_info_id:
+          type: string
+          title: Billing Info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -21012,6 +21019,13 @@ components:
           maxLength: 3
         account:
           "$ref": "#/components/schemas/AccountPurchase"
+        billing_info_id:
+          type: string
+          title: Billing info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         collection_method:
           type: string
           title: Collection method


### PR DESCRIPTION
- Adds `billing_info_id` to `PurchaseCreate` and `SubscriptionCreate` request TypeScript definitions.
- Fixes issue with `count()` and `first()` return types in TypeScript definitions.