### PR TITLE
Ignoring 'internal' tags in changelog generation

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -2,6 +2,6 @@ user=recurly
 project=recurly-client-node
 unreleased=false
 since-tag=3.0.0-beta.2
-exclude-labels=question,bug?,duplicate
+exclude-labels=internal,question,bug?,duplicate
 issues-wo-labels=false
 verbose=false


### PR DESCRIPTION
Internal only update to ignore issues and pull requests with the `internal` label from changelog generation.