### PR TITLE
Generated Latest Changes for v2019-10-10 (get_preview_renewal)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -4380,7 +4380,7 @@ export interface SubscriptionCancel {
 
 export interface SubscriptionPause {
   /**
-    * Number of billing cycles to pause the subscriptions.
+    * Number of billing cycles to pause the subscriptions. A value of 0 will cancel any pending pauses on the subscription.
     */
   remainingPauseCycles?: number | null;
 
@@ -7836,6 +7836,16 @@ export declare class Client {
    * @return {Promise<Subscription>} A subscription.
    */
   convertTrial(subscriptionId: string): Promise<Subscription>;
+  /**
+   * Fetch a preview of a subscription's renewal invoice(s)
+   *
+   * API docs: https://developers.recurly.com/api/v2019-10-10#operation/get_preview_renewal
+   *
+   * 
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @return {Promise<InvoiceCollection>} A preview of the subscription's renewal invoice(s).
+   */
+  getPreviewRenewal(subscriptionId: string): Promise<InvoiceCollection>;
   /**
    * Fetch a subscription's pending change
    *

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -3632,6 +3632,21 @@ class Client extends BaseClient {
   }
 
   /**
+   * Fetch a preview of a subscription's renewal invoice(s)
+   *
+   * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/get_preview_renewal}
+   *
+   *
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @return {Promise<InvoiceCollection>} A preview of the subscription's renewal invoice(s).
+   */
+  async getPreviewRenewal (subscriptionId, options = {}) {
+    let path = '/subscriptions/{subscription_id}/preview_renewal'
+    path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
+    return this._makeRequest('GET', path, null, options)
+  }
+
+  /**
    * Fetch a subscription's pending change
    *
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/get_subscription_change}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12405,6 +12405,43 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/sites/{site_id}/subscriptions/{subscription_id}/preview_renewal":
+    get:
+      tags:
+      - subscription
+      operationId: get_preview_renewal
+      summary: Fetch a preview of a subscription's renewal invoice(s)
+      description: The subscriptions's renewal invoice(s) will be returned if they
+        exist; if they don't (for example, if the subscription is not set to renew),
+        it will return an result with no invoices.
+      parameters:
+      - "$ref": "#/components/parameters/subscription_id"
+      responses:
+        '200':
+          description: A preview of the subscription's renewal invoice(s).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceCollection"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID or subscription ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/sites/{site_id}/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -20568,7 +20605,8 @@ components:
         remaining_pause_cycles:
           type: integer
           title: Remaining pause cycles
-          description: Number of billing cycles to pause the subscriptions.
+          description: Number of billing cycles to pause the subscriptions. A value
+            of 0 will cancel any pending pauses on the subscription.
       required:
       - remaining_pause_cycles
     SubscriptionShipping:


### PR DESCRIPTION
* Adds new endpoint GET /sites/:site_id/subscriptions/:id/preview_renewal which returns a preview of the subscription's renewal invoice(s)