### PR TITLE
Generated Latest Changes for v2021-02-25 (get_preview_renewal)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -4378,7 +4378,7 @@ export interface SubscriptionCancel {
 
 export interface SubscriptionPause {
   /**
-    * Number of billing cycles to pause the subscriptions.
+    * Number of billing cycles to pause the subscriptions. A value of 0 will cancel any pending pauses on the subscription.
     */
   remainingPauseCycles?: number | null;
 
@@ -7872,6 +7872,16 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * @return {Promise<Subscription>} A subscription.
    */
   convertTrial(subscriptionId: string): Promise<Subscription>;
+  /**
+   * Fetch a preview of a subscription's renewal invoice(s)
+   *
+   * API docs: https://developers.recurly.com/api/v2021-02-25#operation/get_preview_renewal
+   *
+   * 
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @return {Promise<InvoiceCollection>} A preview of the subscription's renewal invoice(s).
+   */
+  getPreviewRenewal(subscriptionId: string): Promise<InvoiceCollection>;
   /**
    * Fetch a subscription's pending change
    *

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -3671,6 +3671,21 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
   }
 
   /**
+   * Fetch a preview of a subscription's renewal invoice(s)
+   *
+   * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/get_preview_renewal}
+   *
+   *
+   * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+   * @return {Promise<InvoiceCollection>} A preview of the subscription's renewal invoice(s).
+   */
+  async getPreviewRenewal (subscriptionId, options = {}) {
+    let path = '/subscriptions/{subscription_id}/preview_renewal'
+    path = this._interpolatePath(path, { 'subscription_id': subscriptionId })
+    return this._makeRequest('GET', path, null, options)
+  }
+
+  /**
    * Fetch a subscription's pending change
    *
    * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/get_subscription_change}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12434,6 +12434,43 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/subscriptions/{subscription_id}/preview_renewal":
+    get:
+      tags:
+      - subscription
+      operationId: get_preview_renewal
+      summary: Fetch a preview of a subscription's renewal invoice(s)
+      description: The subscriptions's renewal invoice(s) will be returned if they
+        exist; if they don't (for example, if the subscription is not set to renew),
+        it will return an result with no invoices.
+      parameters:
+      - "$ref": "#/components/parameters/subscription_id"
+      responses:
+        '200':
+          description: A preview of the subscription's renewal invoice(s).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceCollection"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID or subscription ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -20075,7 +20112,8 @@ components:
         remaining_pause_cycles:
           type: integer
           title: Remaining pause cycles
-          description: Number of billing cycles to pause the subscriptions.
+          description: Number of billing cycles to pause the subscriptions. A value
+            of 0 will cancel any pending pauses on the subscription.
       required:
       - remaining_pause_cycles
     SubscriptionShipping:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
* Adds new endpoint GET /sites/:site_id/subscriptions/:id/preview_renewal which returns a preview of the subscription's renewal invoice(s)