### PR TITLE
Generated Latest Changes for v2021-02-25 (Support to new subscription fields and response)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1670,6 +1670,18 @@ export declare class Subscription {
    */
   subtotal?: number | null;
   /**
+   * Estimated tax
+   */
+  tax?: number | null;
+  /**
+   * Tax info
+   */
+  taxInfo?: TaxInfo | null;
+  /**
+   * Estimated total
+   */
+  total?: number | null;
+  /**
    * Collection method
    */
   collectionMethod?: string | null;
@@ -1721,6 +1733,10 @@ export declare class Subscription {
    * Recurring subscriptions paid with ACH will have this attribute set. This timestamp is used for alerting customers to reauthorize in 3 years in accordance with NACHA rules. If a subscription becomes inactive or the billing info is no longer a bank account, this timestamp is cleared.
    */
   bankAccountAuthorizedAt?: Date | null;
+  /**
+   * If present, this subscription's transactions will use the payment gateway with this code.
+   */
+  gatewayCode?: string | null;
   /**
    * Billing Info ID.
    */
@@ -4494,6 +4510,10 @@ export interface SubscriptionUpdate {
     */
   netTerms?: number | null;
   /**
+    * If present, this subscription's transactions will use the payment gateway with this code.
+    */
+  gatewayCode?: string | null;
+  /**
     * Subscription shipping details
     */
   shipping?: SubscriptionShippingUpdate | null;
@@ -4607,6 +4627,11 @@ export interface SubscriptionChangeShippingCreate {
     * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
     */
   amount?: number | null;
+  /**
+    * Assign a shipping address from the account's existing shipping addresses. If this and address are both present, address will take precedence.
+    */
+  addressId?: string | null;
+  address?: ShippingAddressCreate | null;
 
 }
 

--- a/lib/recurly/resources/Subscription.js
+++ b/lib/recurly/resources/Subscription.js
@@ -32,6 +32,7 @@ const Resource = require('../Resource')
  * @prop {string} customerNotes - Customer notes
  * @prop {string} expirationReason - Expiration reason
  * @prop {Date} expiresAt - Expires at
+ * @prop {string} gatewayCode - If present, this subscription's transactions will use the payment gateway with this code.
  * @prop {string} id - Subscription ID
  * @prop {number} netTerms - Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
  * @prop {string} object - Object type
@@ -47,7 +48,10 @@ const Resource = require('../Resource')
  * @prop {SubscriptionShipping} shipping - Subscription shipping details
  * @prop {string} state - State
  * @prop {number} subtotal - Estimated total, before tax.
+ * @prop {number} tax - Estimated tax
+ * @prop {TaxInfo} taxInfo - Tax info
  * @prop {string} termsAndConditions - Terms and conditions
+ * @prop {number} total - Estimated total
  * @prop {number} totalBillingCycles - The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
  * @prop {Date} trialEndsAt - Trial period ends at
  * @prop {Date} trialStartedAt - Trial period started at
@@ -78,6 +82,7 @@ class Subscription extends Resource {
       customerNotes: String,
       expirationReason: String,
       expiresAt: Date,
+      gatewayCode: String,
       id: String,
       netTerms: Number,
       object: String,
@@ -93,7 +98,10 @@ class Subscription extends Resource {
       shipping: 'SubscriptionShipping',
       state: String,
       subtotal: Number,
+      tax: Number,
+      taxInfo: 'TaxInfo',
       termsAndConditions: String,
+      total: Number,
       totalBillingCycles: Number,
       trialEndsAt: Date,
       trialStartedAt: Date,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12611,7 +12611,16 @@ paths:
       - subscription_change
       operationId: create_subscription_change
       summary: Create a new subscription change
-      description: Calling this will overwrite an existing, pending subscription change.
+      description: |
+        Calling this will overwrite an existing, pending subscription change.
+
+        If a subscription has a pending change, and a change is submitted which matches
+        the subscription as it currently exists, the pending change will be deleted,
+        and you will receive a 204 No Content response.
+
+        If a subscription has no pending
+        change, and a change is submitted which matches the subscription as it currently
+        exists, a 422 Unprocessable Entity validation error will be returned.
       parameters:
       - "$ref": "#/components/parameters/subscription_id"
       requestBody:
@@ -12627,6 +12636,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SubscriptionChange"
+        '204':
+          description: The previous pending change was reverted.
         '404':
           description: Incorrect site ID.
           content:
@@ -19443,6 +19454,16 @@ components:
           format: float
           title: Estimated total, before tax.
           minimum: 0
+        tax:
+          type: number
+          format: float
+          title: Estimated tax
+        tax_info:
+          "$ref": "#/components/schemas/TaxInfo"
+        total:
+          type: number
+          format: float
+          title: Estimated total
         collection_method:
           title: Collection method
           default: automatic
@@ -19502,6 +19523,12 @@ components:
             set. This timestamp is used for alerting customers to reauthorize in 3
             years in accordance with NACHA rules. If a subscription becomes inactive
             or the billing info is no longer a bank account, this timestamp is cleared.
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         billing_info_id:
           type: string
           title: Billing Info ID
@@ -19956,6 +19983,13 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+        address_id:
+          type: string
+          titpe: Shipping address ID
+          description: Assign a shipping address from the account's existing shipping
+            addresses. If this and address are both present, address will take precedence.
+        address:
+          "$ref": "#/components/schemas/ShippingAddressCreate"
     SubscriptionCreate:
       type: object
       properties:
@@ -20264,6 +20298,12 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
Generated Latest Changes for v2021-02-25

SubscriptionCreate request format has changed:
* Added `gatewayCode`.

SubscriptionUpdate request format has changed:
* Added `gatewayCode`.

Subscription response format has changed:
* Added `gatewayCode`.

SubscriptionChangeShippingCreate request format has changed:
* Added `address`.
* Added `addressId`.

Added tax information to `Subscription` response
* Added the fields `tax`, `taxInfo` and `total`.

Updated the response for `POST /subscriptions/{subscription_id}/change`.
* Responding with `204 No Content` when the subscription has a pending change, and a change is submitted which matches the subscription as it currently exists.


