### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -4575,7 +4575,7 @@ export interface SubscriptionChangeCreate {
     */
   quantity?: number | null;
   /**
-    * The shipping address can currently only be changed immediately, using SubscriptionUpdate.
+    * Shipping addresses are tied to a customer's account. Each account can have up to 20 different shipping addresses, and if you have enabled multiple subscriptions per account, you can associate different shipping addresses to each subscription.
     */
   shipping?: SubscriptionChangeShippingCreate | null;
   /**

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19961,8 +19961,10 @@ components:
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
-      description: The shipping address can currently only be changed immediately,
-        using SubscriptionUpdate.
+      description: Shipping addresses are tied to a customer's account. Each account
+        can have up to 20 different shipping addresses, and if you have enabled multiple
+        subscriptions per account, you can associate different shipping addresses
+        to each subscription.
       properties:
         method_id:
           type: string
@@ -21777,6 +21779,7 @@ components:
       - roku
       - sepadirectdebit
       - wire_transfer
+      - braintree_v_zero
     CardTypeEnum:
       type: string
       enum:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
- Adds `braintree_v_zero` to the `PaymentMethodEnum`. 
- Updates the `SubscriptionChangeShippingCreate` description to include the number of shipping addresses allowed per account as well as specifying specific shipping addresses to individual subscriptions.