### PR TITLE
Generated Latest Changes for v2019-10-10 (Account Hierarchy Invoice Rollup)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1358,6 +1358,10 @@ export declare class LineItem {
    */
   account?: AccountMini | null;
   /**
+   * The UUID of the account responsible for originating the line item.
+   */
+  billForAccountId?: string | null;
+  /**
    * If the line item is a charge or credit for a subscription, this is its ID.
    */
   subscriptionId?: string | null;

--- a/lib/recurly/resources/LineItem.js
+++ b/lib/recurly/resources/LineItem.js
@@ -19,6 +19,7 @@ const Resource = require('../Resource')
  * @prop {number} amount - `(quantity * unit_amount) - (discount + tax)`
  * @prop {number} avalaraServiceType - Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
  * @prop {number} avalaraTransactionType - Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+ * @prop {string} billForAccountId - The UUID of the account responsible for originating the line item.
  * @prop {Date} createdAt - When the line item was created.
  * @prop {number} creditApplied - The amount of credit from this line item that was applied to the invoice.
  * @prop {string} creditReasonCode - The reason the credit was given when line item is `type=credit`.
@@ -70,6 +71,7 @@ class LineItem extends Resource {
       amount: Number,
       avalaraServiceType: Number,
       avalaraTransactionType: Number,
+      billForAccountId: String,
       createdAt: Date,
       creditApplied: Number,
       creditReasonCode: String,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18279,6 +18279,12 @@ components:
           - carryforward
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21916,6 +21922,8 @@ components:
                 - batch_processing_error
                 - billing_agreement_already_accepted
                 - billing_agreement_not_accepted
+                - billing_agreement_not_found
+                - billing_agreement_replaced
                 - call_issuer
                 - call_issuer_update_cardholder_data
                 - cannot_refund_unsettled_transactions


### PR DESCRIPTION
Add `billForAccountId` field -- the UUID of the account responsible for originating the line item -- to `LineItem` class.

