### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1368,6 +1368,10 @@ export declare class LineItem {
    */
   account?: AccountMini | null;
   /**
+   * The UUID of the account responsible for originating the line item.
+   */
+  billForAccountId?: string | null;
+  /**
    * If the line item is a charge or credit for a subscription, this is its ID.
    */
   subscriptionId?: string | null;
@@ -3103,6 +3107,30 @@ export interface BillingInfoCreate {
     * The International Bank Account Number, up to 34 alphanumeric characters comprising a country code; two check digits; and a number that includes the domestic bank account number, branch identifier, and potential routing information
     */
   iban?: string | null;
+  /**
+    * The name associated with the bank account (ACH, SEPA, Bacs only)
+    */
+  nameOnAccount?: string | null;
+  /**
+    * The bank account number. (ACH, Bacs only)
+    */
+  accountNumber?: string | null;
+  /**
+    * The bank's rounting number. (ACH only)
+    */
+  routingNumber?: string | null;
+  /**
+    * Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
+    */
+  sortCode?: string | null;
+  /**
+    * The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+    */
+  type?: string | null;
+  /**
+    * The bank account type. (ACH only)
+    */
+  accountType?: string | null;
   /**
     * Tax identifier is required if adding a billing info that is a consumer card in Brazil or in Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
     */

--- a/lib/recurly/resources/LineItem.js
+++ b/lib/recurly/resources/LineItem.js
@@ -19,6 +19,7 @@ const Resource = require('../Resource')
  * @prop {number} amount - `(quantity * unit_amount) - (discount + tax)`
  * @prop {number} avalaraServiceType - Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
  * @prop {number} avalaraTransactionType - Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
+ * @prop {string} billForAccountId - The UUID of the account responsible for originating the line item.
  * @prop {Date} createdAt - When the line item was created.
  * @prop {number} creditApplied - The amount of credit from this line item that was applied to the invoice.
  * @prop {string} creditReasonCode - The reason the credit was given when line item is `type=credit`.
@@ -71,6 +72,7 @@ class LineItem extends Resource {
       amount: Number,
       avalaraServiceType: Number,
       avalaraTransactionType: Number,
+      billForAccountId: String,
       createdAt: Date,
       creditApplied: Number,
       creditReasonCode: String,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16345,6 +16345,28 @@ components:
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
             routing information
+        name_on_account:
+          type: string
+          maxLength: 255
+          description: The name associated with the bank account (ACH, SEPA, Bacs
+            only)
+        account_number:
+          type: string
+          maxLength: 255
+          description: The bank account number. (ACH, Bacs only)
+        routing_number:
+          type: string
+          maxLength: 15
+          description: The bank's rounting number. (ACH only)
+        sort_code:
+          type: string
+          maxLength: 15
+          description: Bank identifier code for UK based banks. Required for Bacs
+            based billing infos. (Bacs only)
+        type:
+          "$ref": "#/components/schemas/AchTypeEnum"
+        account_type:
+          "$ref": "#/components/schemas/AchAccountTypeEnum"
         tax_identifier:
           type: string
           description: Tax identifier is required if adding a billing info that is
@@ -17898,6 +17920,12 @@ components:
           "$ref": "#/components/schemas/LegacyCategoryEnum"
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21885,6 +21913,7 @@ components:
       - billing_agreement_already_accepted
       - billing_agreement_not_accepted
       - billing_agreement_not_found
+      - billing_agreement_replaced
       - call_issuer
       - call_issuer_update_cardholder_data
       - cancelled
@@ -22058,3 +22087,15 @@ components:
       - automatic
       - manual
       - trial
+    AchTypeEnum:
+      type: string
+      description: The payment method type for a non-credit card based billing info.
+        The value of `bacs` is the only accepted value (Bacs only)
+      enum:
+      - bacs
+    AchAccountTypeEnum:
+      type: string
+      description: The bank account type. (ACH only)
+      enum:
+      - checking
+      - savings


### PR DESCRIPTION
Support for Account Hierarchy Invoice Rollup:
- Add `billForAccountId` field -- the UUID of the account responsible for originating the line item -- to `LineItem` class.

BillingInfoCreate request format has changed:
- Added `nameOnAccount`
- Added `accountNumber`
- Added `routingNumber`
- Added `sortCode`
- Added `type`
- Added `accountType`