### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1715,6 +1715,10 @@ export declare class Subscription {
    * Billing Info ID.
    */
   billingInfoId?: string | null;
+  /**
+   * The invoice ID of the latest invoice created for an active subscription.
+   */
+  activeInvoiceId?: string | null;
 
 }
 

--- a/lib/recurly/resources/Subscription.js
+++ b/lib/recurly/resources/Subscription.js
@@ -14,6 +14,7 @@ const Resource = require('../Resource')
  * @typedef {Object} Subscription
  * @prop {AccountMini} account - Account mini details
  * @prop {Date} activatedAt - Activated at
+ * @prop {string} activeInvoiceId - The invoice ID of the latest invoice created for an active subscription.
  * @prop {Array.<SubscriptionAddOn>} addOns - Add-ons
  * @prop {number} addOnsTotal - Total price of add-ons
  * @prop {boolean} autoRenew - Whether the subscription renews at the end of its term.
@@ -60,6 +61,7 @@ class Subscription extends Resource {
     return {
       account: 'AccountMini',
       activatedAt: Date,
+      activeInvoiceId: String,
       addOns: ['SubscriptionAddOn'],
       addOnsTotal: Number,
       autoRenew: Boolean,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19999,6 +19999,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.