### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1753,6 +1753,10 @@ export declare class Subscription {
    * Billing Info ID.
    */
   billingInfoId?: string | null;
+  /**
+   * The invoice ID of the latest invoice created for an active subscription.
+   */
+  activeInvoiceId?: string | null;
 
 }
 
@@ -1968,6 +1972,10 @@ export declare class SubscriptionAddOn {
    * The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
    */
   tierType?: string | null;
+  /**
+   * The time at which usage totals are reset for billing purposes.
+   */
+  usageTimeframe?: string | null;
   /**
    * If tiers are provided in the request, all existing tiers on the Subscription Add-on will be removed and replaced by the tiers in the request. If add_on.tier_type is tiered or volume and add_on.usage_type is percentage use percentage_tiers instead.  There must be one tier without an `ending_quantity` value which represents the final tier. 
    */
@@ -2569,6 +2577,10 @@ export declare class AddOn {
    * The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
    */
   tierType?: string | null;
+  /**
+   * The time at which usage totals are reset for billing purposes.
+   */
+  usageTimeframe?: string | null;
   /**
    * Tiers
    */
@@ -4188,6 +4200,10 @@ export interface AddOnCreate {
     * The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models. 
     */
   tierType?: string | null;
+  /**
+    * The time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods. 
+    */
+  usageTimeframe?: string | null;
   /**
     * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to many tiers with `ending_quantity` and `unit_amount` for the desired `currencies`. There must be one tier without an `ending_quantity` value which represents the final tier. 
     */

--- a/lib/recurly/resources/AddOn.js
+++ b/lib/recurly/resources/AddOn.js
@@ -38,6 +38,7 @@ const Resource = require('../Resource')
  * @prop {Array.<Tier>} tiers - Tiers
  * @prop {Date} updatedAt - Last updated at
  * @prop {number} usagePercentage - The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0.
+ * @prop {string} usageTimeframe - The time at which usage totals are reset for billing purposes.
  * @prop {string} usageType - Type of usage, returns usage type if `add_on_type` is `usage`.
  */
 class AddOn extends Resource {
@@ -69,6 +70,7 @@ class AddOn extends Resource {
       tiers: ['Tier'],
       updatedAt: Date,
       usagePercentage: Number,
+      usageTimeframe: String,
       usageType: String
     }
   }

--- a/lib/recurly/resources/Subscription.js
+++ b/lib/recurly/resources/Subscription.js
@@ -14,6 +14,7 @@ const Resource = require('../Resource')
  * @typedef {Object} Subscription
  * @prop {AccountMini} account - Account mini details
  * @prop {Date} activatedAt - Activated at
+ * @prop {string} activeInvoiceId - The invoice ID of the latest invoice created for an active subscription.
  * @prop {Array.<SubscriptionAddOn>} addOns - Add-ons
  * @prop {number} addOnsTotal - Total price of add-ons
  * @prop {boolean} autoRenew - Whether the subscription renews at the end of its term.
@@ -64,6 +65,7 @@ class Subscription extends Resource {
     return {
       account: 'AccountMini',
       activatedAt: Date,
+      activeInvoiceId: String,
       addOns: ['SubscriptionAddOn'],
       addOnsTotal: Number,
       autoRenew: Boolean,

--- a/lib/recurly/resources/SubscriptionAddOn.js
+++ b/lib/recurly/resources/SubscriptionAddOn.js
@@ -28,6 +28,7 @@ const Resource = require('../Resource')
  * @prop {string} unitAmountDecimal - Supports up to 9 decimal places.
  * @prop {Date} updatedAt - Updated at
  * @prop {number} usagePercentage - The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
+ * @prop {string} usageTimeframe - The time at which usage totals are reset for billing purposes.
  */
 class SubscriptionAddOn extends Resource {
   static getSchema () {
@@ -47,7 +48,8 @@ class SubscriptionAddOn extends Resource {
       unitAmount: Number,
       unitAmountDecimal: String,
       updatedAt: Date,
-      usagePercentage: Number
+      usagePercentage: Number,
+      usageTimeframe: String
     }
   }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.15.0",
+      "version": "4.16.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.