### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -560,6 +560,10 @@ export declare class AccountBalanceAmount {
    * Total amount the account is past due.
    */
   amount?: number | null;
+  /**
+   * Total amount for the prepayment credit invoices in a `processing` state on the account.
+   */
+  processingPrepaymentAmount?: number | null;
 
 }
 
@@ -1843,7 +1847,7 @@ export declare class SubscriptionChange {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
   /**
@@ -2199,7 +2203,7 @@ export declare class Pricing {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
 
@@ -2380,7 +2384,7 @@ export declare class PlanPricing {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
 
@@ -2524,7 +2528,7 @@ export declare class AddOnPricing {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
 
@@ -2608,7 +2612,7 @@ export declare class SubscriptionChangePreview {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
   /**
@@ -3621,7 +3625,7 @@ export interface Pricing {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
 
@@ -3990,7 +3994,7 @@ export interface PlanPricing {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
 
@@ -4114,7 +4118,7 @@ export interface AddOnPricing {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
 
@@ -4544,7 +4548,7 @@ export interface SubscriptionUpdate {
     */
   netTerms?: number | null;
   /**
-    * This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use the POST subscription change route instead.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
   /**
@@ -4605,7 +4609,7 @@ export interface SubscriptionChangeCreate {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
   /**

--- a/lib/recurly/resources/AccountBalanceAmount.js
+++ b/lib/recurly/resources/AccountBalanceAmount.js
@@ -14,12 +14,14 @@ const Resource = require('../Resource')
  * @typedef {Object} AccountBalanceAmount
  * @prop {number} amount - Total amount the account is past due.
  * @prop {string} currency - 3-letter ISO 4217 currency code.
+ * @prop {number} processingPrepaymentAmount - Total amount for the prepayment credit invoices in a `processing` state on the account.
  */
 class AccountBalanceAmount extends Resource {
   static getSchema () {
     return {
       amount: Number,
-      currency: String
+      currency: String,
+      processingPrepaymentAmount: Number
     }
   }
 }

--- a/lib/recurly/resources/AddOnPricing.js
+++ b/lib/recurly/resources/AddOnPricing.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * AddOnPricing
  * @typedef {Object} AddOnPricing
  * @prop {string} currency - 3-letter ISO 4217 currency code.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit price
  */
 class AddOnPricing extends Resource {

--- a/lib/recurly/resources/PlanPricing.js
+++ b/lib/recurly/resources/PlanPricing.js
@@ -14,7 +14,7 @@ const Resource = require('../Resource')
  * @typedef {Object} PlanPricing
  * @prop {string} currency - 3-letter ISO 4217 currency code.
  * @prop {number} setupFee - Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit price
  */
 class PlanPricing extends Resource {

--- a/lib/recurly/resources/Pricing.js
+++ b/lib/recurly/resources/Pricing.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * Pricing
  * @typedef {Object} Pricing
  * @prop {string} currency - 3-letter ISO 4217 currency code.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit price
  */
 class Pricing extends Resource {

--- a/lib/recurly/resources/SubscriptionChange.js
+++ b/lib/recurly/resources/SubscriptionChange.js
@@ -28,7 +28,7 @@ const Resource = require('../Resource')
  * @prop {string} setupFeeRevenueScheduleType - Setup fee revenue schedule type
  * @prop {SubscriptionShipping} shipping - Subscription shipping details
  * @prop {string} subscriptionId - The ID of the subscription that is going to be changed.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit amount
  * @prop {Date} updatedAt - Updated at
  */

--- a/lib/recurly/resources/SubscriptionChangePreview.js
+++ b/lib/recurly/resources/SubscriptionChangePreview.js
@@ -28,7 +28,7 @@ const Resource = require('../Resource')
  * @prop {string} setupFeeRevenueScheduleType - Setup fee revenue schedule type
  * @prop {SubscriptionShipping} shipping - Subscription shipping details
  * @prop {string} subscriptionId - The ID of the subscription that is going to be changed.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit amount
  * @prop {Date} updatedAt - Updated at
  */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15426,11 +15426,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15556,11 +15558,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15714,6 +15718,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19127,9 +19137,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19294,9 +19303,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -19318,9 +19326,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20289,9 +20296,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20401,9 +20407,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20862,9 +20867,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferredLocale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processingPrepaymentAmount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `taxInclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.