### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -206,7 +206,7 @@ export declare class Account {
    */
   dunningCampaignId?: string | null;
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is enabled. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise plan. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
    */
   invoiceTemplateId?: string | null;
   address?: Address | null;
@@ -556,6 +556,10 @@ export declare class AccountBalanceAmount {
    * Total amount the account is past due.
    */
   amount?: number | null;
+  /**
+   * Total amount for the prepayment credit invoices in a `processing` state on the account.
+   */
+  processingPrepaymentAmount?: number | null;
 
 }
 
@@ -1881,7 +1885,7 @@ export declare class SubscriptionChange {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
   /**
@@ -2285,7 +2289,7 @@ export declare class Pricing {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
 
@@ -2466,7 +2470,7 @@ export declare class PlanPricing {
    */
   unitAmount?: number | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
 
@@ -2622,7 +2626,7 @@ export declare class AddOnPricing {
    */
   unitAmountDecimal?: string | null;
   /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   * This field is deprecated. Please do not use it.
    */
   taxInclusive?: boolean | null;
 
@@ -3044,7 +3048,7 @@ export interface AccountCreate {
     */
   dunningCampaignId?: string | null;
   /**
-    * Unique ID to identify an invoice template.  Available when the Invoice Customization feature is enabled.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
+    * Unique ID to identify an invoice template.  Available when the site is on a Pro or Enterprise plan.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
     */
   invoiceTemplateId?: string | null;
   address?: Address | null;
@@ -3245,11 +3249,11 @@ export interface BillingInfoCreate {
     */
   accountType?: string | null;
   /**
-    * Tax identifier is required if adding a billing info that is a consumer card in Brazil or in Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
+    * Tax identifier is required if adding a billing info that is a consumer card in Brazil or in Argentina. This would be the customer's CPF/CNPJ (Brazil) and CUIT (Argentina). CPF, CNPJ and CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
     */
   taxIdentifier?: string | null;
   /**
-    * This field and a value of `cpf` or `cuit` are required if adding a billing info that is an elo or hipercard type in Brazil or in Argentina.
+    * This field and a value of `cpf`, `cnpj` or `cuit` are required if adding a billing info that is an elo or hipercard type in Brazil or in Argentina.
     */
   taxIdentifierType?: string | null;
   /**
@@ -3336,7 +3340,7 @@ export interface AccountUpdate {
     */
   dunningCampaignId?: string | null;
   /**
-    * Unique ID to identify an invoice template.  Available when the Invoice Customization feature is enabled.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
+    * Unique ID to identify an invoice template.  Available when the site is on a Pro or Enterprise plan.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
     */
   invoiceTemplateId?: string | null;
   address?: Address | null;
@@ -3724,7 +3728,7 @@ export interface Pricing {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
 
@@ -4093,7 +4097,7 @@ export interface PlanPricing {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
 
@@ -4229,7 +4233,7 @@ export interface AddOnPricing {
     */
   unitAmountDecimal?: string | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
 
@@ -4739,7 +4743,7 @@ export interface SubscriptionUpdate {
     */
   gatewayCode?: string | null;
   /**
-    * This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use the POST subscription change route instead.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
   /**
@@ -4800,7 +4804,7 @@ export interface SubscriptionChangeCreate {
     */
   unitAmount?: number | null;
   /**
-    * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+    * This field is deprecated. Please do not use it.
     */
   taxInclusive?: boolean | null;
   /**
@@ -5068,7 +5072,7 @@ export interface AccountPurchase {
     */
   dunningCampaignId?: string | null;
   /**
-    * Unique ID to identify an invoice template.  Available when the Invoice Customization feature is enabled.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
+    * Unique ID to identify an invoice template.  Available when the site is on a Pro or Enterprise plan.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
     */
   invoiceTemplateId?: string | null;
   address?: Address | null;
@@ -8353,6 +8357,21 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    *
    * API docs: https://developers.recurly.com/api/v2021-02-25#operation/get_preview_renewal
    *
+   * @example
+   * try {
+   *   const invoiceCollection = await client.getPreviewRenewal(subscriptionId)
+   *   console.log('Fetched Renewal Preview with total: ', invoiceCollection.chargeInvoice.total)
+   * } catch (err) {
+   *   if (err instanceof recurly.errors.NotFoundError) {
+   *     // If the request was not found, you may want to alert the user or
+   *     // just return null
+   *     console.log('Resource Not Found')
+   *   } else {
+   *     // If we don't know what to do with the err, we should
+   *     // probably re-raise and let our web framework and logger handle it
+   *     console.log('Unknown Error: ', err)
+   *   }
+   * }
    * 
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<InvoiceCollection>} A preview of the subscription's renewal invoice(s).

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -3721,6 +3721,21 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    *
    * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/get_preview_renewal}
    *
+   * @example
+   * try {
+   *   const invoiceCollection = await client.getPreviewRenewal(subscriptionId)
+   *   console.log('Fetched Renewal Preview with total: ', invoiceCollection.chargeInvoice.total)
+   * } catch (err) {
+   *   if (err instanceof recurly.errors.NotFoundError) {
+   *     // If the request was not found, you may want to alert the user or
+   *     // just return null
+   *     console.log('Resource Not Found')
+   *   } else {
+   *     // If we don't know what to do with the err, we should
+   *     // probably re-raise and let our web framework and logger handle it
+   *     console.log('Unknown Error: ', err)
+   *   }
+   * }
    *
    * @param {string} subscriptionId - Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
    * @return {Promise<InvoiceCollection>} A preview of the subscription's renewal invoice(s).

--- a/lib/recurly/resources/Account.js
+++ b/lib/recurly/resources/Account.js
@@ -33,7 +33,7 @@ const Resource = require('../Resource')
  * @prop {boolean} hasPausedSubscription - Indicates if the account has a paused subscription.
  * @prop {string} hostedLoginToken - The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: `https://{subdomain}.recurly.com/account/{hosted_login_token}`.
  * @prop {string} id
- * @prop {string} invoiceTemplateId - Unique ID to identify an invoice template. Available when the Invoice Customization feature is enabled. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
+ * @prop {string} invoiceTemplateId - Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise plan. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
  * @prop {string} lastName
  * @prop {string} object - Object type
  * @prop {string} parentAccountId - The UUID of the parent account associated with this account.

--- a/lib/recurly/resources/AccountBalanceAmount.js
+++ b/lib/recurly/resources/AccountBalanceAmount.js
@@ -14,12 +14,14 @@ const Resource = require('../Resource')
  * @typedef {Object} AccountBalanceAmount
  * @prop {number} amount - Total amount the account is past due.
  * @prop {string} currency - 3-letter ISO 4217 currency code.
+ * @prop {number} processingPrepaymentAmount - Total amount for the prepayment credit invoices in a `processing` state on the account.
  */
 class AccountBalanceAmount extends Resource {
   static getSchema () {
     return {
       amount: Number,
-      currency: String
+      currency: String,
+      processingPrepaymentAmount: Number
     }
   }
 }

--- a/lib/recurly/resources/AddOnPricing.js
+++ b/lib/recurly/resources/AddOnPricing.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * AddOnPricing
  * @typedef {Object} AddOnPricing
  * @prop {string} currency - 3-letter ISO 4217 currency code.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided.
  * @prop {string} unitAmountDecimal - Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`. If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
  */

--- a/lib/recurly/resources/PlanPricing.js
+++ b/lib/recurly/resources/PlanPricing.js
@@ -14,7 +14,7 @@ const Resource = require('../Resource')
  * @typedef {Object} PlanPricing
  * @prop {string} currency - 3-letter ISO 4217 currency code.
  * @prop {number} setupFee - Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit price
  */
 class PlanPricing extends Resource {

--- a/lib/recurly/resources/Pricing.js
+++ b/lib/recurly/resources/Pricing.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * Pricing
  * @typedef {Object} Pricing
  * @prop {string} currency - 3-letter ISO 4217 currency code.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit price
  */
 class Pricing extends Resource {

--- a/lib/recurly/resources/SubscriptionChange.js
+++ b/lib/recurly/resources/SubscriptionChange.js
@@ -27,7 +27,7 @@ const Resource = require('../Resource')
  * @prop {string} revenueScheduleType - Revenue schedule type
  * @prop {SubscriptionShipping} shipping - Subscription shipping details
  * @prop {string} subscriptionId - The ID of the subscription that is going to be changed.
- * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+ * @prop {boolean} taxInclusive - This field is deprecated. Please do not use it.
  * @prop {number} unitAmount - Unit amount
  * @prop {Date} updatedAt - Updated at
  */

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12519,7 +12519,97 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-      x-code-samples: []
+      x-code-samples:
+      - lang: Node.js
+        source: |
+          try {
+            const invoiceCollection = await client.getPreviewRenewal(subscriptionId)
+            console.log('Fetched Renewal Preview with total: ', invoiceCollection.chargeInvoice.total)
+          } catch (err) {
+            if (err instanceof recurly.errors.NotFoundError) {
+              // If the request was not found, you may want to alert the user or
+              // just return null
+              console.log('Resource Not Found')
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              invoice_collection = client.get_preview_renewal(subscription_id)
+              print("Fetched Renewal Preview with total: %s" % invoice_collection.charge_invoice.total)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+        source: |
+          try
+          {
+              InvoiceCollection invoiceCollection = client.GetPreviewRenewal(subscriptionId);
+              Console.WriteLine($"Fetched Renewal Preview with total {invoiceCollection.ChargeInvoice.Total}");
+          }
+          catch (Recurly.Errors.NotFound ex)
+          {
+              // If the resource was not found
+              // we may want to alert the user or just return null
+              Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+          }
+          catch (Recurly.Errors.ApiError ex)
+          {
+              // Use ApiError to catch a generic error from the API
+              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+          }
+      - lang: Ruby
+        source: |
+          begin
+            invoice_collection = @client.get_preview_renewal(
+              subscription_id: subscription_id
+            )
+            puts "Fetched Renewal Preview with total: #{invoice_collection.charge_invoice.total}"
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+        source: |
+          try {
+              final InvoiceCollection invoiceCollection = client.getPreviewRenewal(subscriptionId);
+              System.out.println("Fetched Renewal Preview with total: " + invoiceCollection.getChargeInvoice().getTotal());
+          } catch (ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+      - lang: PHP
+        source: |
+          try {
+              $invoiceCollection = $client->getPreviewRenewal($subscription_id);
+
+              echo 'Fetched Renewal Preview with total: ' . $invoiceCollection->getChargeInvoice()->getTotal() . PHP_EOL;
+              var_dump($invoiceCollection);
+          } catch (\Recurly\Errors\NotFound $e) {
+              // Could not find the resource, you may want to inform the user
+              // or just return a NULL
+              echo 'Could not find resource.' . PHP_EOL;
+              var_dump($e);
+          } catch (\Recurly\RecurlyError $e) {
+              // Something bad happened... tell the user so that they can fix it?
+              echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+          }
+      - lang: Go
+        source: "invoiceCollection, err := client.GetPreviewRenewal(subID)\nif e,
+          ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+          {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+          Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Renewal
+          Preview with total: %f\", invoiceCollection.ChargeInvoice.Total)"
   "/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -15852,7 +15942,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template.  Available when
-            the Invoice Customization feature is enabled.  Used to specify which invoice
+            the site is on a Pro or Enterprise plan.  Used to specify which invoice
             template, if any, should be used to generate invoices for the account.
         address:
           "$ref": "#/components/schemas/Address"
@@ -15935,7 +16025,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template. Available when the
-            Invoice Customization feature is enabled. Used to specify if a non-default
+            site is on a Pro or Enterprise plan. Used to specify if a non-default
             invoice template will be used to generate invoices for the account. For
             sites without multiple invoice templates enabled, the default template
             will always be used.
@@ -16040,6 +16130,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -16805,11 +16901,12 @@ components:
           type: string
           description: Tax identifier is required if adding a billing info that is
             a consumer card in Brazil or in Argentina. This would be the customer's
-            CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for
-            all residents who pay taxes in Brazil and Argentina respectively.
+            CPF/CNPJ (Brazil) and CUIT (Argentina). CPF, CNPJ and CUIT are tax identifiers
+            for all residents who pay taxes in Brazil and Argentina respectively.
         tax_identifier_type:
-          description: This field and a value of `cpf` or `cuit` are required if adding
-            a billing info that is an elo or hipercard type in Brazil or in Argentina.
+          description: This field and a value of `cpf`, `cnpj` or `cuit` are required
+            if adding a billing info that is an elo or hipercard type in Brazil or
+            in Argentina.
           "$ref": "#/components/schemas/TaxIdentifierTypeEnum"
         primary_payment_method:
           type: boolean
@@ -19143,9 +19240,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19307,9 +19403,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
     TierPricing:
@@ -19356,9 +19451,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20397,9 +20491,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20491,9 +20584,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20932,9 +21024,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
@@ -22074,11 +22164,13 @@ components:
       - ko-KR
       - nl-BE
       - nl-NL
+      - pl-PL
       - pt-BR
       - pt-PT
       - ro-RO
       - ru-RU
       - sk-SK
+      - sv-SE
       - tr-TR
       - zh-CN
     BillToEnum:
@@ -22752,6 +22844,7 @@ components:
       type: string
       enum:
       - cpf
+      - cnpj
       - cuit
     DunningCycleTypeEnum:
       type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.16.0",
+      "version": "4.17.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferredLocale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processingPrepaymentAmount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `taxInclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.
- The invoice templates feature is now generally available to merchants with a Pro or Elite plan Recurly subscription. See [our documentation](https://docs.recurly.com/docs/invoice-customization#create-and-assigning-invoice-templates) for more information about that feature.