### PR TITLE
Fixes bug with putDunningCampaignBulkUpdate

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -9106,10 +9106,11 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * API docs: https://developers.recurly.com/api/v2021-02-25#operation/put_dunning_campaign_bulk_update
    *
    * 
+   * @param {string} dunningCampaignId - Dunning Campaign ID, e.g. `e28zov4fw0v2`.
    * @param {DunningCampaignsBulkUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {DunningCampaignsBulkUpdate}
    * @return {Promise<DunningCampaignsBulkUpdateResponse>} A list of updated plans.
    */
-  putDunningCampaignBulkUpdate(body: DunningCampaignsBulkUpdate): Promise<DunningCampaignsBulkUpdateResponse>;
+  putDunningCampaignBulkUpdate(dunningCampaignId: string, body: DunningCampaignsBulkUpdate): Promise<DunningCampaignsBulkUpdateResponse>;
   /**
    * Show the invoice templates for a site
    *

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -4466,12 +4466,13 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/put_dunning_campaign_bulk_update}
    *
    *
+   * @param {string} dunningCampaignId - Dunning Campaign ID, e.g. `e28zov4fw0v2`.
    * @param {DunningCampaignsBulkUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {DunningCampaignsBulkUpdate}
    * @return {Promise<DunningCampaignsBulkUpdateResponse>} A list of updated plans.
    */
-  async putDunningCampaignBulkUpdate (body, options = {}) {
+  async putDunningCampaignBulkUpdate (dunningCampaignId, body, options = {}) {
     let path = '/dunning_campaigns/{dunning_campaign_id}/bulk_update'
-    path = this._interpolatePath(path)
+    path = this._interpolatePath(path, { 'dunning_campaign_id': dunningCampaignId })
     return this._makeRequest('PUT', path, body, options)
   }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14922,6 +14922,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -20774,7 +20776,7 @@ components:
             zero then a `method_id` or `method_code` is required.
         address_id:
           type: string
-          titpe: Shipping address ID
+          title: Shipping address ID
           description: Assign a shipping address from the account's existing shipping
             addresses. If this and address are both present, address will take precedence.
         address:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.19.0",
+      "version": "4.20.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
The `putDunningCampaignBulkUpdate` method was missing the `dunningCampaignId` parameter, which is used to construct the request URL.