### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -2117,7 +2117,7 @@ export declare class SubscriptionChangeBillingInfo {
 
 export declare class SubscriptionRampIntervalResponse {
   /**
-   * Represents how many billing cycles are included in a ramp interval.
+   * Represents the billing cycle where a ramp interval starts.
    */
   startingBillingCycle?: number | null;
   /**
@@ -2502,7 +2502,7 @@ export declare class Plan {
 
 export declare class PlanRampInterval {
   /**
-   * Represents the first billing cycle of a ramp.
+   * Represents the billing cycle where a ramp interval starts.
    */
   startingBillingCycle?: number | null;
   /**
@@ -3429,6 +3429,14 @@ export interface BillingInfoVerify {
 
 }
 
+export interface BillingInfoVerifyCVV {
+  /**
+    * Unique security code for a credit card.
+    */
+  verificationValue?: string | null;
+
+}
+
 export interface CouponRedemptionCreate {
   /**
     * Coupon ID
@@ -4162,7 +4170,7 @@ export interface PlanCreate {
 
 export interface PlanRampInterval {
   /**
-    * Represents the first billing cycle of a ramp.
+    * Represents the billing cycle where a ramp interval starts.
     */
   startingBillingCycle?: number | null;
   /**
@@ -4804,7 +4812,7 @@ export interface SubscriptionAddOnPercentageTier {
 
 export interface SubscriptionRampInterval {
   /**
-    * Represents how many billing cycles are included in a ramp interval.
+    * Represents the billing cycle where a ramp interval starts.
     */
   startingBillingCycle?: number | null;
   /**
@@ -5799,6 +5807,17 @@ export declare class Client {
    * @return {Promise<Transaction>} Transaction information from verify.
    */
   verifyBillingInfo(accountId: string, options?: object): Promise<Transaction>;
+  /**
+   * Verify an account's credit card billing cvv
+   *
+   * API docs: https://developers.recurly.com/api/v2021-02-25#operation/verify_billing_info_cvv
+   *
+   * 
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {BillingInfoVerifyCVV} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoVerifyCVV}
+   * @return {Promise<Transaction>} Transaction information from verify.
+   */
+  verifyBillingInfoCvv(accountId: string, body: BillingInfoVerifyCVV): Promise<Transaction>;
   /**
    * Get the list of billing information associated with an account
    *

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -563,6 +563,22 @@ class Client extends BaseClient {
   }
 
   /**
+   * Verify an account's credit card billing cvv
+   *
+   * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/verify_billing_info_cvv}
+   *
+   *
+   * @param {string} accountId - Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param {BillingInfoVerifyCVV} body - The object representing the JSON request to send to the server. It should conform to the schema of {BillingInfoVerifyCVV}
+   * @return {Promise<Transaction>} Transaction information from verify.
+   */
+  async verifyBillingInfoCvv (accountId, body, options = {}) {
+    let path = '/accounts/{account_id}/billing_info/verify_cvv'
+    path = this._interpolatePath(path, { 'account_id': accountId })
+    return this._makeRequest('POST', path, body, options)
+  }
+
+  /**
    * Get the list of billing information associated with an account
    *
    * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/list_billing_infos}

--- a/lib/recurly/resources/PlanRampInterval.js
+++ b/lib/recurly/resources/PlanRampInterval.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * PlanRampInterval
  * @typedef {Object} PlanRampInterval
  * @prop {Array.<PlanRampPricing>} currencies - Represents the price for the ramp interval.
- * @prop {number} startingBillingCycle - Represents the first billing cycle of a ramp.
+ * @prop {number} startingBillingCycle - Represents the billing cycle where a ramp interval starts.
  */
 class PlanRampInterval extends Resource {
   static getSchema () {

--- a/lib/recurly/resources/SubscriptionRampIntervalResponse.js
+++ b/lib/recurly/resources/SubscriptionRampIntervalResponse.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * SubscriptionRampIntervalResponse
  * @typedef {Object} SubscriptionRampIntervalResponse
  * @prop {number} remainingBillingCycles - Represents how many billing cycles are left in a ramp interval.
- * @prop {number} startingBillingCycle - Represents how many billing cycles are included in a ramp interval.
+ * @prop {number} startingBillingCycle - Represents the billing cycle where a ramp interval starts.
  * @prop {number} unitAmount - Represents the price for the ramp interval.
  */
 class SubscriptionRampIntervalResponse extends Resource {

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2441,6 +2441,47 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction)"
+  "/accounts/{account_id}/billing_info/verify_cvv":
+    post:
+      tags:
+      - billing_info
+      operationId: verify_billing_info_cvv
+      summary: Verify an account's credit card billing cvv
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BillingInfoVerifyCVV"
+      responses:
+        '200':
+          description: Transaction information from verify.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Transaction"
+        '429':
+          description: Over limit error. A credit card can only be checked 3 times
+            in 24 hours.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Invalid billing information, or error running the verification
+            transaction.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorMayHaveTransaction"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/billing_infos":
     get:
       tags:
@@ -16942,6 +16983,12 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+    BillingInfoVerifyCVV:
+      type: object
+      properties:
+        verification_value:
+          type: string
+          description: Unique security code for a credit card.
     Coupon:
       type: object
       properties:
@@ -19275,7 +19322,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21239,7 +21286,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21250,12 +21297,14 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
         unit_amount:
-          type: integer
+          type: number
+          format: float
+          title: Unit price
           description: Represents the price for the ramp interval.
     TaxInfo:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.20.0",
+      "version": "4.21.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
- Added `/accounts/{account_id}/billing_info/verify_cvv` route which takes a `verification_value` and returns a `transaction` if the `verification_value` matches the cvv of the credit card on file. A `422` is returned if the `verification_value` does not match the credit card on file and the a `429` is returned if the same credit card is checked more than 3 times in 24 hours.