### PR TITLE
Generated Latest Changes for v2019-10-10(Decimal Usage and Quantities)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1434,6 +1434,10 @@ export declare class LineItem {
    */
   quantity?: number | null;
   /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  quantityDecimal?: string | null;
+  /**
    * Positive amount for a charge, negative amount for a credit.
    */
   unitAmount?: number | null;
@@ -1489,6 +1493,10 @@ export declare class LineItem {
    * For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
    */
   refundedQuantity?: number | null;
+  /**
+   * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  refundedQuantityDecimal?: string | null;
   /**
    * The amount of credit from this line item that was applied to the invoice.
    */
@@ -2047,7 +2055,7 @@ export declare class SubscriptionChangeBillingInfo {
 
 export declare class SubscriptionRampIntervalResponse {
   /**
-   * Represents how many billing cycles are included in a ramp interval.
+   * Represents the billing cycle where a ramp interval starts.
    */
   startingBillingCycle?: number | null;
   /**
@@ -2412,7 +2420,7 @@ export declare class Plan {
 
 export declare class PlanRampInterval {
   /**
-   * Represents the first billing cycle of a ramp.
+   * Represents the billing cycle where a ramp interval starts.
    */
   startingBillingCycle?: number | null;
   /**
@@ -2745,7 +2753,7 @@ export declare class Usage {
    */
   merchantTag?: string | null;
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   amount?: number | null;
   /**
@@ -3930,6 +3938,10 @@ export interface LineItemRefund {
     */
   quantity?: number | null;
   /**
+    * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+    */
+  quantityDecimal?: string | null;
+  /**
     * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used on line items that have a start and end date. 
     */
   prorate?: boolean | null;
@@ -4058,7 +4070,7 @@ export interface PlanCreate {
 
 export interface PlanRampInterval {
   /**
-    * Represents the first billing cycle of a ramp.
+    * Represents the billing cycle where a ramp interval starts.
     */
   startingBillingCycle?: number | null;
   /**
@@ -4612,7 +4624,7 @@ export interface SubscriptionAddOnTier {
 
 export interface SubscriptionRampInterval {
   /**
-    * Represents how many billing cycles are included in a ramp interval.
+    * Represents the billing cycle where a ramp interval starts.
     */
   startingBillingCycle?: number | null;
   /**
@@ -4846,7 +4858,7 @@ export interface UsageCreate {
     */
   merchantTag?: string | null;
   /**
-    * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+    * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
     */
   amount?: number | null;
   /**
@@ -8753,10 +8765,11 @@ export declare class Client {
    * API docs: https://developers.recurly.com/api/v2019-10-10#operation/put_dunning_campaign_bulk_update
    *
    * 
+   * @param {string} dunningCampaignId - Dunning Campaign ID, e.g. `e28zov4fw0v2`.
    * @param {DunningCampaignsBulkUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {DunningCampaignsBulkUpdate}
    * @return {Promise<DunningCampaignsBulkUpdateResponse>} A list of updated plans.
    */
-  putDunningCampaignBulkUpdate(body: DunningCampaignsBulkUpdate): Promise<DunningCampaignsBulkUpdateResponse>;
+  putDunningCampaignBulkUpdate(dunningCampaignId: string, body: DunningCampaignsBulkUpdate): Promise<DunningCampaignsBulkUpdateResponse>;
 
 }
 

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -4311,12 +4311,13 @@ class Client extends BaseClient {
    * API docs: {@link https://developers.recurly.com/api/v2019-10-10#operation/put_dunning_campaign_bulk_update}
    *
    *
+   * @param {string} dunningCampaignId - Dunning Campaign ID, e.g. `e28zov4fw0v2`.
    * @param {DunningCampaignsBulkUpdate} body - The object representing the JSON request to send to the server. It should conform to the schema of {DunningCampaignsBulkUpdate}
    * @return {Promise<DunningCampaignsBulkUpdateResponse>} A list of updated plans.
    */
-  async putDunningCampaignBulkUpdate (body, options = {}) {
+  async putDunningCampaignBulkUpdate (dunningCampaignId, body, options = {}) {
     let path = '/dunning_campaigns/{dunning_campaign_id}/bulk_update'
-    path = this._interpolatePath(path)
+    path = this._interpolatePath(path, { 'dunning_campaign_id': dunningCampaignId })
     return this._makeRequest('PUT', path, body, options)
   }
 }

--- a/lib/recurly/resources/LineItem.js
+++ b/lib/recurly/resources/LineItem.js
@@ -43,8 +43,10 @@ const Resource = require('../Resource')
  * @prop {string} productCode - For plan-related line items this will be the plan's code, for add-on related line items it will be the add-on's code. For item-related line items it will be the item's `external_sku`.
  * @prop {number} prorationRate - When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
  * @prop {number} quantity - This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
+ * @prop {string} quantityDecimal - A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
  * @prop {boolean} refund - Refund?
  * @prop {number} refundedQuantity - For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+ * @prop {string} refundedQuantityDecimal - A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
  * @prop {string} revenueScheduleType - Revenue schedule type
  * @prop {ShippingAddress} shippingAddress
  * @prop {Date} startDate - If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date.
@@ -96,8 +98,10 @@ class LineItem extends Resource {
       productCode: String,
       prorationRate: Number,
       quantity: Number,
+      quantityDecimal: String,
       refund: Boolean,
       refundedQuantity: Number,
+      refundedQuantityDecimal: String,
       revenueScheduleType: String,
       shippingAddress: 'ShippingAddress',
       startDate: Date,

--- a/lib/recurly/resources/PlanRampInterval.js
+++ b/lib/recurly/resources/PlanRampInterval.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * PlanRampInterval
  * @typedef {Object} PlanRampInterval
  * @prop {Array.<PlanRampPricing>} currencies - Represents the price for the ramp interval.
- * @prop {number} startingBillingCycle - Represents the first billing cycle of a ramp.
+ * @prop {number} startingBillingCycle - Represents the billing cycle where a ramp interval starts.
  */
 class PlanRampInterval extends Resource {
   static getSchema () {

--- a/lib/recurly/resources/SubscriptionRampIntervalResponse.js
+++ b/lib/recurly/resources/SubscriptionRampIntervalResponse.js
@@ -13,7 +13,7 @@ const Resource = require('../Resource')
  * SubscriptionRampIntervalResponse
  * @typedef {Object} SubscriptionRampIntervalResponse
  * @prop {number} remainingBillingCycles - Represents how many billing cycles are left in a ramp interval.
- * @prop {number} startingBillingCycle - Represents how many billing cycles are included in a ramp interval.
+ * @prop {number} startingBillingCycle - Represents the billing cycle where a ramp interval starts.
  * @prop {number} unitAmount - Represents the price for the ramp interval.
  */
 class SubscriptionRampIntervalResponse extends Resource {

--- a/lib/recurly/resources/Usage.js
+++ b/lib/recurly/resources/Usage.js
@@ -12,7 +12,7 @@ const Resource = require('../Resource')
 /**
  * Usage
  * @typedef {Object} Usage
- * @prop {number} amount - The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+ * @prop {number} amount - The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
  * @prop {Date} billedAt - When the usage record was billed on an invoice.
  * @prop {Date} createdAt - When the usage record was created in Recurly.
  * @prop {string} id

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14463,6 +14463,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -18423,6 +18425,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18503,6 +18513,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18544,6 +18561,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -19335,7 +19360,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21093,7 +21118,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21104,7 +21129,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
@@ -21533,10 +21558,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           type: string
           enum:
@@ -21609,10 +21635,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantityDecimal` and `refundedQuantityDecimal` properties to `LineItem` class
- Add `quantityDecimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Fix Bulk Dunning Campaign update
- Update `putDunningCampaignBulkUpdate` method to receive the `dunningCampaignId`