### PR TITLE
Generated Latest Changes for v2021-02-25(Decimal Usage and Quantities and DunningEvent new fields)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1247,6 +1247,14 @@ export declare class Invoice {
    * Unique ID to identify the dunning campaign used when dunning the invoice. For sites without multiple dunning campaigns enabled, this will always be the default dunning campaign.
    */
   dunningCampaignId?: string | null;
+  /**
+   * Number of times the event was sent.
+   */
+  dunningEventsSent?: number | null;
+  /**
+   * Last communication attempt.
+   */
+  finalDunningEvent?: boolean | null;
 
 }
 
@@ -1456,6 +1464,10 @@ export declare class LineItem {
    */
   quantity?: number | null;
   /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  quantityDecimal?: string | null;
+  /**
    * Positive amount for a charge, negative amount for a credit.
    */
   unitAmount?: number | null;
@@ -1515,6 +1527,10 @@ export declare class LineItem {
    * For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
    */
   refundedQuantity?: number | null;
+  /**
+   * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  refundedQuantityDecimal?: string | null;
   /**
    * The amount of credit from this line item that was applied to the invoice.
    */
@@ -2807,7 +2823,7 @@ export declare class Usage {
    */
   merchantTag?: string | null;
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   amount?: number | null;
   /**
@@ -3333,11 +3349,11 @@ export interface BillingInfoCreate {
     */
   backupPaymentMethod?: boolean | null;
   /**
-    * Use for Adyen HPP billing info.
+    * Use for Adyen HPP billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.
     */
   externalHppType?: string | null;
   /**
-    * Use for Online Banking billing info.
+    * Use for Online Banking billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.
     */
   onlineBankingPaymentType?: string | null;
   cardType?: string | null;
@@ -4041,6 +4057,10 @@ export interface LineItemRefund {
     * Line item quantity to be refunded.
     */
   quantity?: number | null;
+  /**
+    * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+    */
+  quantityDecimal?: string | null;
   /**
     * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used on line items that have a start and end date. 
     */
@@ -5063,7 +5083,7 @@ export interface UsageCreate {
     */
   merchantTag?: string | null;
   /**
-    * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+    * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
     */
   amount?: number | null;
   /**

--- a/lib/recurly/resources/Invoice.js
+++ b/lib/recurly/resources/Invoice.js
@@ -25,6 +25,8 @@ const Resource = require('../Resource')
  * @prop {number} discount - Total discounts applied to this invoice.
  * @prop {Date} dueAt - Date invoice is due. This is the date the net terms are reached.
  * @prop {string} dunningCampaignId - Unique ID to identify the dunning campaign used when dunning the invoice. For sites without multiple dunning campaigns enabled, this will always be the default dunning campaign.
+ * @prop {number} dunningEventsSent - Number of times the event was sent.
+ * @prop {boolean} finalDunningEvent - Last communication attempt.
  * @prop {boolean} hasMoreLineItems - Identifies if the invoice has more line items than are returned in `line_items`. If `has_more_line_items` is `true`, then a request needs to be made to the `list_invoice_line_items` endpoint.
  * @prop {string} id - Invoice ID
  * @prop {Array.<LineItem>} lineItems - Line Items
@@ -67,6 +69,8 @@ class Invoice extends Resource {
       discount: Number,
       dueAt: Date,
       dunningCampaignId: String,
+      dunningEventsSent: Number,
+      finalDunningEvent: Boolean,
       hasMoreLineItems: Boolean,
       id: String,
       lineItems: ['LineItem'],

--- a/lib/recurly/resources/LineItem.js
+++ b/lib/recurly/resources/LineItem.js
@@ -43,8 +43,10 @@ const Resource = require('../Resource')
  * @prop {string} productCode - For plan-related line items this will be the plan's code, for add-on related line items it will be the add-on's code. For item-related line items it will be the item's `external_sku`.
  * @prop {number} prorationRate - When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
  * @prop {number} quantity - This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
+ * @prop {string} quantityDecimal - A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
  * @prop {boolean} refund - Refund?
  * @prop {number} refundedQuantity - For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+ * @prop {string} refundedQuantityDecimal - A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
  * @prop {string} revenueScheduleType - Revenue schedule type
  * @prop {ShippingAddress} shippingAddress
  * @prop {Date} startDate - If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date.
@@ -97,8 +99,10 @@ class LineItem extends Resource {
       productCode: String,
       prorationRate: Number,
       quantity: Number,
+      quantityDecimal: String,
       refund: Boolean,
       refundedQuantity: Number,
+      refundedQuantityDecimal: String,
       revenueScheduleType: String,
       shippingAddress: 'ShippingAddress',
       startDate: Date,

--- a/lib/recurly/resources/Usage.js
+++ b/lib/recurly/resources/Usage.js
@@ -12,7 +12,7 @@ const Resource = require('../Resource')
 /**
  * Usage
  * @typedef {Object} Usage
- * @prop {number} amount - The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+ * @prop {number} amount - The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
  * @prop {Date} billedAt - When the usage record was billed on an invoice.
  * @prop {Date} createdAt - When the usage record was created in Recurly.
  * @prop {string} id

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.21.0",
+      "version": "4.22.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantityDecimal` and `refundedQuantityDecimal` properties to `LineItem` class
- Add `quantityDecimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`