### PR TITLE
Generated Latest Changes for v2019-10-10 (usedTaxService on Invoice)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1172,6 +1172,10 @@ export declare class Invoice {
    */
   taxInfo?: TaxInfo | null;
   /**
+   * Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
+   */
+  usedTaxService?: boolean | null;
+  /**
    * VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
    */
   vatNumber?: string | null;
@@ -2143,7 +2147,7 @@ export declare class CustomFieldDefinition {
    */
   name?: string | null;
   /**
-   * The access control applied inside Recurly's admin UI: - `api_only` - No one will be able to view or edit this field's data via the admin UI. - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but   editing will only be available via the API. - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI. 
+   * The access control applied inside Recurly's admin UI: - `api_only` - No one will be able to view or edit this field's data via the admin UI. - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but   editing will only be available via the API. - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI. - `set_only` - Users with the Customers role will be able to set this field's data via the admin console. 
    */
   userAccess?: string | null;
   /**
@@ -3189,6 +3193,10 @@ export interface BillingInfoCreate {
     * *STRONGLY RECOMMENDED*
     */
   cvv?: string | null;
+  /**
+    * 3-letter ISO 4217 currency code.
+    */
+  currency?: string | null;
   /**
     * VAT number
     */

--- a/lib/recurly/resources/CustomFieldDefinition.js
+++ b/lib/recurly/resources/CustomFieldDefinition.js
@@ -21,7 +21,7 @@ const Resource = require('../Resource')
  * @prop {string} relatedType - Related Recurly object type
  * @prop {string} tooltip - Displayed as a tooltip when editing the field in the Recurly admin UI.
  * @prop {Date} updatedAt - Last updated at
- * @prop {string} userAccess - The access control applied inside Recurly's admin UI: - `api_only` - No one will be able to view or edit this field's data via the admin UI. - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but   editing will only be available via the API. - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
+ * @prop {string} userAccess - The access control applied inside Recurly's admin UI: - `api_only` - No one will be able to view or edit this field's data via the admin UI. - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but   editing will only be available via the API. - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI. - `set_only` - Users with the Customers role will be able to set this field's data via the admin console.
  */
 class CustomFieldDefinition extends Resource {
   static getSchema () {

--- a/lib/recurly/resources/Invoice.js
+++ b/lib/recurly/resources/Invoice.js
@@ -46,6 +46,7 @@ const Resource = require('../Resource')
  * @prop {Array.<Transaction>} transactions - Transactions
  * @prop {string} type - Invoices are either charge, credit, or legacy invoices.
  * @prop {Date} updatedAt - Last updated at
+ * @prop {boolean} usedTaxService - Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
  * @prop {string} vatNumber - VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
  * @prop {string} vatReverseChargeNotes - VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
  */
@@ -86,6 +87,7 @@ class Invoice extends Resource {
       transactions: ['Transaction'],
       type: String,
       updatedAt: Date,
+      usedTaxService: Boolean,
       vatNumber: String,
       vatReverseChargeNotes: String
     }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -224,8 +224,8 @@ tags:
   x-displayName: Site
 - name: custom_field_definition
   x-displayName: Custom Field Definition
-  description: Describes the fields that can use used as custom fields on accounts
-    or subscriptions.
+  description: Describes the fields that can be used as custom fields on accounts,
+    items, line-items (one time charges), plans, or subscriptions.
 - name: item
   x-displayName: Item
   description: |-
@@ -15561,7 +15561,9 @@ components:
           - es-MX
           - es-US
           - fi-FI
+          - fr-BE
           - fr-CA
+          - fr-CH
           - fr-FR
           - hi-IN
           - it-IT
@@ -15698,7 +15700,9 @@ components:
           - es-MX
           - es-US
           - fi-FI
+          - fr-BE
           - fr-CA
+          - fr-CH
           - fr-FR
           - hi-IN
           - it-IT
@@ -16619,6 +16623,9 @@ components:
           title: Security code or CVV
           description: "*STRONGLY RECOMMENDED*"
           maxLength: 4
+        currency:
+          type: string
+          description: 3-letter ISO 4217 currency code.
         vat_number:
           type: string
           title: VAT number
@@ -17468,10 +17475,12 @@ components:
             - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but
               editing will only be available via the API.
             - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
+            - `set_only` - Users with the Customers role will be able to set this field's data via the admin console.
           enum:
           - api_only
           - read_only
           - write
+          - set_only
         display_name:
           type: string
           title: Display name
@@ -17966,6 +17975,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "3.25.0",
+      "version": "3.26.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `usedTaxService`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.