### PR TITLE
Generated Latest Changes for v2021-02-25 (usedTaxService on Invoice)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1409,6 +1409,10 @@ export declare class Invoice {
    */
   taxInfo?: TaxInfo | null;
   /**
+   * Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
+   */
+  usedTaxService?: boolean | null;
+  /**
    * VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
    */
   vatNumber?: string | null;

--- a/lib/recurly/resources/Invoice.js
+++ b/lib/recurly/resources/Invoice.js
@@ -49,6 +49,7 @@ const Resource = require('../Resource')
  * @prop {Array.<Transaction>} transactions - Transactions
  * @prop {string} type - Invoices are either charge, credit, or legacy invoices.
  * @prop {Date} updatedAt - Last updated at
+ * @prop {boolean} usedTaxService - Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
  * @prop {string} uuid - Invoice UUID
  * @prop {string} vatNumber - VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
  * @prop {string} vatReverseChargeNotes - VAT Reverse Charge Notes only appear if you have EU VAT enabled or are using your own Avalara AvaTax account and the customer is in the EU, has a VAT number, and is in a different country than your own. This will default to the VAT Reverse Charge Notes text specified on the Tax Settings page in your Recurly admin, unless custom notes were created with the original subscription.
@@ -93,6 +94,7 @@ class Invoice extends Resource {
       transactions: ['Transaction'],
       type: String,
       updatedAt: Date,
+      usedTaxService: Boolean,
       uuid: String,
       vatNumber: String,
       vatReverseChargeNotes: String

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19032,6 +19032,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number
@@ -24043,7 +24050,9 @@ components:
       - es-MX
       - es-US
       - fi-FI
+      - fr-BE
       - fr-CA
+      - fr-CH
       - fr-FR
       - hi-IN
       - it-IT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.32.0",
+  "version": "4.33.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.32.0",
+      "version": "4.33.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `usedTaxService`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.