### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1273,19 +1273,19 @@ export declare class InvoiceAddress {
 
 export declare class TaxInfo {
   /**
-   * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+   * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries. Not present when Avalara for Communications is enabled.
    */
   type?: string | null;
   /**
-   * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.
+   * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for Communications is enabled.
    */
   region?: string | null;
   /**
-   * Rate
+   * The combined tax rate. Not present when Avalara for Communications is enabled.
    */
   rate?: number | null;
   /**
-   * Provides additional tax details for Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItem.
+   * Provides additional tax details for Communications taxes when Avalara for Communications is enabled or Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
    */
   taxDetails?: TaxDetail[] | null;
 
@@ -1293,11 +1293,11 @@ export declare class TaxInfo {
 
 export declare class TaxDetail {
   /**
-   * Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+   * Provides the tax type for the region or type of Comminications tax when Avalara for Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
    */
   type?: string | null;
   /**
-   * Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code.
+   * Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code. Not present when Avalara for Communications is enabled.
    */
   region?: string | null;
   /**
@@ -1308,6 +1308,18 @@ export declare class TaxDetail {
    * The total tax applied for this tax type.
    */
   tax?: number | null;
+  /**
+   * Provides the name of the Communications tax applied. Present only when Avalara for Communications is enabled.
+   */
+  name?: string | null;
+  /**
+   * Provides the jurisdiction level for the Communications tax applied. Example values include city, state and federal. Present only when Avalara for Communications is enabled.
+   */
+  level?: string | null;
+  /**
+   * Whether or not the line item is taxable. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
+   */
+  billable?: boolean | null;
 
 }
 

--- a/lib/recurly/resources/TaxDetail.js
+++ b/lib/recurly/resources/TaxDetail.js
@@ -12,14 +12,20 @@ const Resource = require('../Resource')
 /**
  * TaxDetail
  * @typedef {Object} TaxDetail
+ * @prop {boolean} billable - Whether or not the line item is taxable. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
+ * @prop {string} level - Provides the jurisdiction level for the Communications tax applied. Example values include city, state and federal. Present only when Avalara for Communications is enabled.
+ * @prop {string} name - Provides the name of the Communications tax applied. Present only when Avalara for Communications is enabled.
  * @prop {number} rate - Provides the tax rate for the region.
- * @prop {string} region - Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code.
+ * @prop {string} region - Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code. Not present when Avalara for Communications is enabled.
  * @prop {number} tax - The total tax applied for this tax type.
- * @prop {string} type - Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+ * @prop {string} type - Provides the tax type for the region or type of Comminications tax when Avalara for Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
  */
 class TaxDetail extends Resource {
   static getSchema () {
     return {
+      billable: Boolean,
+      level: String,
+      name: String,
       rate: Number,
       region: String,
       tax: Number,

--- a/lib/recurly/resources/TaxInfo.js
+++ b/lib/recurly/resources/TaxInfo.js
@@ -12,10 +12,10 @@ const Resource = require('../Resource')
 /**
  * TaxInfo
  * @typedef {Object} TaxInfo
- * @prop {number} rate - Rate
- * @prop {string} region - Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.
- * @prop {Array.<TaxDetail>} taxDetails - Provides additional tax details for Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItem.
- * @prop {string} type - Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+ * @prop {number} rate - The combined tax rate. Not present when Avalara for Communications is enabled.
+ * @prop {string} region - Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for Communications is enabled.
+ * @prop {Array.<TaxDetail>} taxDetails - Provides additional tax details for Communications taxes when Avalara for Communications is enabled or Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is enabled.
+ * @prop {string} type - Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries. Not present when Avalara for Communications is enabled.
  */
 class TaxInfo extends Resource {
   static getSchema () {

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21336,23 +21336,29 @@ components:
           description: Provides the tax type as "vat" for EU VAT, "usst" for U.S.
             Sales Tax, or the 2 letter country code for country level tax types like
             Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+            Not present when Avalara for Communications is enabled.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For U.S. Sales
             Tax, this will be the 2 letter state code. For EU VAT this will be the
             2 letter country code. For all country level tax types, this will display
-            the regional tax, like VAT, GST, or PST.
+            the regional tax, like VAT, GST, or PST. Not present when Avalara for
+            Communications is enabled.
         rate:
           type: number
           format: float
           title: Rate
+          description: The combined tax rate. Not present when Avalara for Communications
+            is enabled.
         tax_details:
           type: array
-          description: Provides additional tax details for Canadian Sales Tax when
-            there is tax applied at both the country and province levels. This will
-            only be populated for the Invoice response when fetching a single invoice
-            and not for the InvoiceList or LineItem.
+          description: Provides additional tax details for Communications taxes when
+            Avalara for Communications is enabled or Canadian Sales Tax when there
+            is tax applied at both the country and province levels. This will only
+            be populated for the Invoice response when fetching a single invoice and
+            not for the InvoiceList or LineItemList. Only populated for a single LineItem
+            fetch when Avalara for Communications is enabled.
           items:
             "$ref": "#/components/schemas/TaxDetail"
     TaxDetail:
@@ -21362,13 +21368,15 @@ components:
         type:
           type: string
           title: Type
-          description: Provides the tax type for the region. For Canadian Sales Tax,
+          description: Provides the tax type for the region or type of Comminications
+            tax when Avalara for Communications is enabled. For Canadian Sales Tax,
             this will be GST, HST, QST or PST.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For Canadian
             Sales Tax, this will be either the 2 letter province code or country code.
+            Not present when Avalara for Communications is enabled.
         rate:
           type: number
           format: float
@@ -21379,6 +21387,22 @@ components:
           format: float
           title: Tax
           description: The total tax applied for this tax type.
+        name:
+          type: string
+          title: Name
+          description: Provides the name of the Communications tax applied. Present
+            only when Avalara for Communications is enabled.
+        level:
+          type: string
+          title: Level
+          description: Provides the jurisdiction level for the Communications tax
+            applied. Example values include city, state and federal. Present only
+            when Avalara for Communications is enabled.
+        billable:
+          type: boolean
+          title: Billable
+          description: Whether or not the line item is taxable. Only populated for
+            a single LineItem fetch when Avalara for Communications is enabled.
     Transaction:
       type: object
       properties:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "3.26.0",
+      "version": "3.27.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
LineItem response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`
  * `billable`

Invoice response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`