### PR TITLE
Generated Latest Changes for v2021-02-25 (Ramp Dates, Net Terms, Invoice Business Entity, External Subscriptions)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -785,6 +785,10 @@ export declare class InvoiceMini {
    */
   number?: string | null;
   /**
+   * Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
+   */
+  businessEntityId?: string | null;
+  /**
    * Invoice type
    */
   type?: string | null;
@@ -1233,6 +1237,10 @@ export declare class ExternalSubscription {
    */
   autoRenew?: boolean | null;
   /**
+   * An indication of whether or not the external subscription is in a grace period.
+   */
+  inGracePeriod?: boolean | null;
+  /**
    * Identifier of the app that generated the external subscription.
    */
   appIdentifier?: string | null;
@@ -1241,7 +1249,7 @@ export declare class ExternalSubscription {
    */
   quantity?: number | null;
   /**
-   * External subscriptions can be active, canceled, expired, or future.
+   * External subscriptions can be active, canceled, expired, or past_due.
    */
   state?: string | null;
   /**
@@ -1249,9 +1257,21 @@ export declare class ExternalSubscription {
    */
   activatedAt?: Date | null;
   /**
+   * When the external subscription was canceled in the external platform.
+   */
+  canceledAt?: Date | null;
+  /**
    * When the external subscription expires in the external platform.
    */
   expiresAt?: Date | null;
+  /**
+   * When the external subscription trial period started in the external platform.
+   */
+  trialStartedAt?: Date | null;
+  /**
+   * When the external subscription trial period ends in the external platform.
+   */
+  trialEndsAt?: Date | null;
   /**
    * When the external subscription was created in Recurly.
    */
@@ -1383,9 +1403,13 @@ export declare class Invoice {
    */
   poNumber?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   netTerms?: number | null;
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+   */
+  netTermsType?: string | null;
   address?: InvoiceAddress | null;
   shippingAddress?: ShippingAddress | null;
   /**
@@ -1991,9 +2015,13 @@ export declare class Subscription {
    */
   poNumber?: string | null;
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   netTerms?: number | null;
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+   */
+  netTermsType?: string | null;
   /**
    * Terms and conditions
    */
@@ -2405,6 +2433,14 @@ export declare class SubscriptionRampIntervalResponse {
    * Represents how many billing cycles are left in a ramp interval.
    */
   remainingBillingCycles?: number | null;
+  /**
+   * Date the ramp interval starts
+   */
+  startingOn?: Date | null;
+  /**
+   * Date the ramp interval ends
+   */
+  endingOn?: Date | null;
   /**
    * Represents the price for the ramp interval.
    */
@@ -4099,9 +4135,13 @@ export interface InvoiceCreate {
     */
   creditCustomerNotes?: string | null;
   /**
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     */
   netTerms?: number | null;
+  /**
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+    */
+  netTermsType?: string | null;
   /**
     * For manual invoicing, this identifies the PO number associated with the subscription.
     */
@@ -5401,9 +5441,13 @@ export interface SubscriptionCreate {
     */
   poNumber?: string | null;
   /**
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     */
   netTerms?: number | null;
+  /**
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+    */
+  netTermsType?: string | null;
   /**
     * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
     */
@@ -5562,9 +5606,13 @@ export interface SubscriptionUpdate {
     */
   poNumber?: string | null;
   /**
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     */
   netTerms?: number | null;
+  /**
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+    */
+  netTermsType?: string | null;
   /**
     * If present, this subscription's transactions will use the payment gateway with this code.
     */
@@ -5667,9 +5715,13 @@ export interface SubscriptionChangeCreate {
     */
   poNumber?: string | null;
   /**
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer normally paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.  For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     */
   netTerms?: number | null;
+  /**
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+    */
+  netTermsType?: string | null;
   /**
     * An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
     */
@@ -5794,9 +5846,13 @@ export interface PurchaseCreate {
     */
   poNumber?: string | null;
   /**
-    * Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+    * Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
     */
   netTerms?: number | null;
+  /**
+    * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled. 
+    */
+  netTermsType?: string | null;
   /**
     * Terms and conditions to be put on the purchase invoice.
     */

--- a/lib/recurly/resources/ExternalSubscription.js
+++ b/lib/recurly/resources/ExternalSubscription.js
@@ -16,15 +16,19 @@ const Resource = require('../Resource')
  * @prop {Date} activatedAt - When the external subscription was activated in the external platform.
  * @prop {string} appIdentifier - Identifier of the app that generated the external subscription.
  * @prop {boolean} autoRenew - An indication of whether or not the external subscription will auto-renew at the expiration date.
+ * @prop {Date} canceledAt - When the external subscription was canceled in the external platform.
  * @prop {Date} createdAt - When the external subscription was created in Recurly.
  * @prop {Date} expiresAt - When the external subscription expires in the external platform.
  * @prop {string} externalId - The id of the subscription in the external systems., I.e. Apple App Store or Google Play Store.
  * @prop {ExternalProductReferenceMini} externalProductReference - External Product Reference details
  * @prop {string} id - System-generated unique identifier for an external subscription ID, e.g. `e28zov4fw0v2`.
+ * @prop {boolean} inGracePeriod - An indication of whether or not the external subscription is in a grace period.
  * @prop {Date} lastPurchased - When a new billing event occurred on the external subscription in conjunction with a recent billing period, reactivation or upgrade/downgrade.
  * @prop {string} object - Object type
  * @prop {number} quantity - An indication of the quantity of a subscribed item's quantity.
- * @prop {string} state - External subscriptions can be active, canceled, expired, or future.
+ * @prop {string} state - External subscriptions can be active, canceled, expired, or past_due.
+ * @prop {Date} trialEndsAt - When the external subscription trial period ends in the external platform.
+ * @prop {Date} trialStartedAt - When the external subscription trial period started in the external platform.
  * @prop {Date} updatedAt - When the external subscription was updated in Recurly.
  */
 class ExternalSubscription extends Resource {
@@ -34,15 +38,19 @@ class ExternalSubscription extends Resource {
       activatedAt: Date,
       appIdentifier: String,
       autoRenew: Boolean,
+      canceledAt: Date,
       createdAt: Date,
       expiresAt: Date,
       externalId: String,
       externalProductReference: 'ExternalProductReferenceMini',
       id: String,
+      inGracePeriod: Boolean,
       lastPurchased: Date,
       object: String,
       quantity: Number,
       state: String,
+      trialEndsAt: Date,
+      trialStartedAt: Date,
       updatedAt: Date
     }
   }

--- a/lib/recurly/resources/Invoice.js
+++ b/lib/recurly/resources/Invoice.js
@@ -31,7 +31,8 @@ const Resource = require('../Resource')
  * @prop {boolean} hasMoreLineItems - Identifies if the invoice has more line items than are returned in `line_items`. If `has_more_line_items` is `true`, then a request needs to be made to the `list_invoice_line_items` endpoint.
  * @prop {string} id - Invoice ID
  * @prop {Array.<LineItem>} lineItems - Line Items
- * @prop {number} netTerms - Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+ * @prop {number} netTerms - Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
+ * @prop {string} netTermsType - Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled.
  * @prop {string} number - If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
  * @prop {string} object - Object type
  * @prop {string} origin - The event that created the invoice.
@@ -78,6 +79,7 @@ class Invoice extends Resource {
       id: String,
       lineItems: ['LineItem'],
       netTerms: Number,
+      netTermsType: String,
       number: String,
       object: String,
       origin: String,

--- a/lib/recurly/resources/InvoiceMini.js
+++ b/lib/recurly/resources/InvoiceMini.js
@@ -12,6 +12,7 @@ const Resource = require('../Resource')
 /**
  * InvoiceMini
  * @typedef {Object} InvoiceMini
+ * @prop {string} businessEntityId - Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
  * @prop {string} id - Invoice ID
  * @prop {string} number - Invoice number
  * @prop {string} object - Object type
@@ -21,6 +22,7 @@ const Resource = require('../Resource')
 class InvoiceMini extends Resource {
   static getSchema () {
     return {
+      businessEntityId: String,
       id: String,
       number: String,
       object: String,

--- a/lib/recurly/resources/Subscription.js
+++ b/lib/recurly/resources/Subscription.js
@@ -36,7 +36,8 @@ const Resource = require('../Resource')
  * @prop {Date} expiresAt - Expires at
  * @prop {string} gatewayCode - If present, this subscription's transactions will use the payment gateway with this code.
  * @prop {string} id - Subscription ID
- * @prop {number} netTerms - Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+ * @prop {number} netTerms - Integer paired with `Net Terms Type` and representing the number of days past the current date (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms Type) that the invoice will become past due. For any value, an additional 24 hours is added to ensure the customer has the entire last day to make payment before becoming past due.  For example:  If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.  When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`. For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
+ * @prop {string} netTermsType - Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date. When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.  This field is only available when the EOM Net Terms feature is enabled.
  * @prop {string} object - Object type
  * @prop {Date} pausedAt - Null unless subscription is paused or will pause at the end of the current billing period.
  * @prop {SubscriptionChange} pendingChange - Subscription Change
@@ -92,6 +93,7 @@ class Subscription extends Resource {
       gatewayCode: String,
       id: String,
       netTerms: Number,
+      netTermsType: String,
       object: String,
       pausedAt: Date,
       pendingChange: 'SubscriptionChange',

--- a/lib/recurly/resources/SubscriptionRampIntervalResponse.js
+++ b/lib/recurly/resources/SubscriptionRampIntervalResponse.js
@@ -12,15 +12,19 @@ const Resource = require('../Resource')
 /**
  * SubscriptionRampIntervalResponse
  * @typedef {Object} SubscriptionRampIntervalResponse
+ * @prop {Date} endingOn - Date the ramp interval ends
  * @prop {number} remainingBillingCycles - Represents how many billing cycles are left in a ramp interval.
  * @prop {number} startingBillingCycle - Represents the billing cycle where a ramp interval starts.
+ * @prop {Date} startingOn - Date the ramp interval starts
  * @prop {number} unitAmount - Represents the price for the ramp interval.
  */
 class SubscriptionRampIntervalResponse extends Resource {
   static getSchema () {
     return {
+      endingOn: Date,
       remainingBillingCycles: Number,
       startingBillingCycle: Number,
+      startingOn: Date,
       unitAmount: Number
     }
   }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15202,7 +15202,7 @@ paths:
 
         Use for **Adyen HPP** and **Online Banking** transaction requests.
         This runs the validations but not the transactions.
-        The API request allows the inclusion of one of the following fields: **external_hpp_type** with `'adyen'` and **online_banking_payment_type** with `'ideal'` or `'sofort'` in the **billing_info** object.
+        The API request allows the inclusion of the following field: **external_hpp_type** with `'adyen'` in the **billing_info** object.
 
         For additional information regarding shipping fees, please see https://docs.recurly.com/docs/shipping
 
@@ -18291,6 +18291,7 @@ components:
           "$ref": "#/components/schemas/ExternalHppTypeEnum"
         online_banking_payment_type:
           "$ref": "#/components/schemas/OnlineBankingPaymentTypeEnum"
+          deprecated: true
         card_type:
           "$ref": "#/components/schemas/CardTypeEnum"
     BillingInfoVerify:
@@ -19332,13 +19333,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         address:
           "$ref": "#/components/schemas/InvoiceAddress"
         shipping_address:
@@ -19516,13 +19528,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
-          default: 0
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
+          default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         po_number:
           type: string
           title: Purchase order number
@@ -19629,6 +19652,11 @@ components:
         number:
           type: string
           title: Invoice number
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
         type:
           title: Invoice type
           "$ref": "#/components/schemas/InvoiceTypeEnum"
@@ -21600,13 +21628,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -22162,13 +22201,17 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer normally paired with `Net Terms Type` and representing the number of days past
+            the current date (for `net` Net Terms Type) or days after the last day of the current
+            month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+            change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22373,13 +22416,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22549,13 +22603,24 @@ components:
         net_terms:
           type: integer
           title: Terms that the subscription is due on
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         gateway_code:
           type: string
           title: Gateway Code
@@ -22694,6 +22759,14 @@ components:
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
+        starting_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval starts
+        ending_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval ends
         unit_amount:
           type: number
           format: float
@@ -23253,13 +23326,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -23765,6 +23849,12 @@ components:
           description: An indication of whether or not the external subscription will
             auto-renew at the expiration date.
           default: false
+        in_grace_period:
+          type: boolean
+          title: In grace period
+          description: An indication of whether or not the external subscription is
+            in a grace period.
+          default: false
         app_identifier:
           type: string
           title: App identifier
@@ -23778,18 +23868,37 @@ components:
         state:
           type: string
           description: External subscriptions can be active, canceled, expired, or
-            future.
+            past_due.
+          default: active
         activated_at:
           type: string
           format: date-time
           title: Activated at
           description: When the external subscription was activated in the external
             platform.
+        canceled_at:
+          type: string
+          format: date-time
+          title: Canceled at
+          description: When the external subscription was canceled in the external
+            platform.
         expires_at:
           type: string
           format: date-time
           title: Expires at
           description: When the external subscription expires in the external platform.
+        trial_started_at:
+          type: string
+          format: date-time
+          title: Trial started at
+          description: When the external subscription trial period started in the
+            external platform.
+        trial_ends_at:
+          type: string
+          format: date-time
+          title: Trial ends at
+          description: When the external subscription trial period ends in the external
+            platform.
         created_at:
           type: string
           format: date-time
@@ -24773,6 +24882,19 @@ components:
       - at_range_start
       - evenly
       - never
+    NetTermsTypeEnum:
+      type: string
+      title: Net Terms Type
+      description: |
+        Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+        This field is only available when the EOM Net Terms feature is enabled.
+      enum:
+      - net
+      - eom
+      default: net
     InvoiceTypeEnum:
       type: string
       enum:
@@ -25039,6 +25161,7 @@ components:
       - venmo
       - wire_transfer
       - braintree_v_zero
+      - boleto
     CardTypeEnum:
       type: string
       enum:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.37.0",
+  "version": "4.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.37.0",
+      "version": "4.38.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
- Adds `NetTermsType` to the `Subscription`, `SubscriptionChange`, `Purchase`, and `Invoice` resources
- Adds `BusinessEntityId` to the `InvoiceMini` resource
- Adds `StartingOn` and `EndingOn` to `SubscriptionRampIntervalResponse` resources
- Adds `InGracePeriod `, `CanceledAt`, `TrialStartedAt`, `TrialEndsAt` to `ExternalSubscription` resources