### PR TITLE
Generated Latest Changes for v2021-02-25 (Line Item Refunds)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1941,7 +1941,7 @@ export declare class LineItem {
    */
   avalaraServiceType?: number | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   taxCode?: string | null;
   /**
@@ -2835,7 +2835,7 @@ export declare class Item {
    */
   avalaraServiceType?: number | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   taxCode?: string | null;
   /**
@@ -3065,7 +3065,7 @@ export declare class Plan {
    */
   avalaraServiceType?: number | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   taxCode?: string | null;
   /**
@@ -3241,7 +3241,7 @@ export declare class AddOn {
    */
   avalaraServiceType?: number | null;
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
    */
   taxCode?: string | null;
   /**
@@ -4536,7 +4536,7 @@ export interface LineItemCreate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
     */
   taxCode?: string | null;
   /**
@@ -4819,7 +4819,7 @@ export interface ItemCreate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
     */
   taxCode?: string | null;
   /**
@@ -4899,7 +4899,7 @@ export interface ItemUpdate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
     */
   taxCode?: string | null;
   /**
@@ -5114,9 +5114,13 @@ export interface InvoiceRefund {
     */
   type?: string | null;
   /**
-    * The amount to be refunded. The amount will be split between the line items. If no amount is specified, it will default to refunding the total refundable amount on the invoice. 
+    * The amount to be refunded. The amount will be split between the line items. If `type` is "amount" and no amount is specified, it will default to refunding the total refundable amount on the invoice. Can only be present if `type` is "amount". 
     */
   amount?: number | null;
+  /**
+    * The percentage of the remaining balance to be refunded. The percentage will be split between the line items. If `type` is "percentage" and no percentage is specified, it will default to refunding 100% of the refundable amount on the invoice. Can only be present if `type` is "percentage".
+    */
+  percentage?: number | null;
   /**
     * The line items to be refunded. This is required when `type=line_items`.
     */
@@ -5142,13 +5146,21 @@ export interface LineItemRefund {
     */
   id?: string | null;
   /**
-    * Line item quantity to be refunded.
+    * Line item quantity to be refunded. Must be less than or equal to the `quantity_remaining`. If `quantity_decimal`, `amount`, and `percentage` are not present, `quantity` is required. If `amount` or `percentage` is present, `quantity` must be absent.
     */
   quantity?: number | null;
   /**
-    * A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+    * Decimal quantity to refund. The `quantity_decimal` will be used to refund charges that has a NOT null quantity decimal. Must be less than or equal to the `quantity_decimal_remaining`. If `quantity`, `amount`, and `percentage` are not present, `quantity_decimal` is required. If `amount` or `percentage` is present, `quantity_decimal` must be absent. The Decimal Quantity feature must be enabled to utilize this field.
     */
   quantityDecimal?: string | null;
+  /**
+    * The specific amount to be refunded from the adjustment. Must be less than or equal to the adjustment's remaining balance. If `quantity`, `quantity_decimal` and `percentage` are not present, `amount` is required. If `quantity`, `quantity_decimal`, or `percentage` is present, `amount` must be absent.
+    */
+  amount?: number | null;
+  /**
+    * The percentage of the adjustment's remaining balance to refund. If `quantity`, `quantity_decimal` and `amount_in_cents` are not present, `percentage` is required. If `quantity`, `quantity_decimal` or `amount_in_cents` is present, `percentage` must be absent.
+    */
+  percentage?: number | null;
   /**
     * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used on line items that have a start and end date. 
     */
@@ -5274,7 +5286,7 @@ export interface PlanCreate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
     */
   taxCode?: string | null;
   /**
@@ -5454,7 +5466,7 @@ export interface AddOnCreate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
     */
   taxCode?: string | null;
   /**
@@ -5650,7 +5662,7 @@ export interface PlanUpdate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
     */
   taxCode?: string | null;
   /**
@@ -5734,7 +5746,7 @@ export interface AddOnUpdate {
     */
   avalaraServiceType?: number | null;
   /**
-    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`, `physical`, or `digital`. If an `Item` is associated to the `AddOn` then `tax code` must be absent.
+    * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If an `Item` is associated to the `AddOn` then `tax_code` must be absent.
     */
   taxCode?: string | null;
   /**

--- a/lib/recurly/resources/AddOn.js
+++ b/lib/recurly/resources/AddOn.js
@@ -36,7 +36,7 @@ const Resource = require('../Resource')
  * @prop {string} revenueGlAccountId - The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
  * @prop {string} revenueScheduleType - When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
  * @prop {string} state - Add-ons can be either active or inactive.
- * @prop {string} taxCode - Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+ * @prop {string} taxCode - Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
  * @prop {string} tierType - The pricing model for the add-on.  For more information, [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our [Guide](https://recurly.com/developers/guides/item-addon-guide.html) for an overview of how to configure quantity-based pricing models.
  * @prop {Array.<Tier>} tiers - Tiers
  * @prop {Date} updatedAt - Last updated at

--- a/lib/recurly/resources/Item.js
+++ b/lib/recurly/resources/Item.js
@@ -30,7 +30,7 @@ const Resource = require('../Resource')
  * @prop {string} revenueGlAccountId - The ID of a general ledger account. General ledger accounts are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
  * @prop {string} revenueScheduleType - Revenue schedule type
  * @prop {string} state - The current state of the item.
- * @prop {string} taxCode - Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+ * @prop {string} taxCode - Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
  * @prop {boolean} taxExempt - `true` exempts tax on the item, `false` applies tax on the item.
  * @prop {Date} updatedAt - Last updated at
  */

--- a/lib/recurly/resources/LineItem.js
+++ b/lib/recurly/resources/LineItem.js
@@ -60,7 +60,7 @@ const Resource = require('../Resource')
  * @prop {string} subscriptionId - If the line item is a charge or credit for a subscription, this is its ID.
  * @prop {number} subtotal - `quantity * unit_amount`
  * @prop {number} tax - The tax amount for the line item.
- * @prop {string} taxCode - Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+ * @prop {string} taxCode - Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
  * @prop {boolean} taxExempt - `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
  * @prop {boolean} taxInclusive - Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to utilize this flag.
  * @prop {TaxInfo} taxInfo - Only for merchants using Recurly's In-The-Box taxes.

--- a/lib/recurly/resources/Plan.js
+++ b/lib/recurly/resources/Plan.js
@@ -36,7 +36,7 @@ const Resource = require('../Resource')
  * @prop {string} setupFeeAccountingCode - Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.
  * @prop {string} setupFeeRevenueScheduleType - Setup fee revenue schedule type
  * @prop {string} state - The current state of the plan.
- * @prop {string} taxCode - Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
+ * @prop {string} taxCode - Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
  * @prop {boolean} taxExempt - `true` exempts tax on the plan, `false` applies tax on the plan.
  * @prop {number} totalBillingCycles - Automatically terminate subscriptions after a defined number of billing cycles. Number of billing cycles before the plan automatically stops renewing, defaults to `null` for continuous, automatic renewal.
  * @prop {number} trialLength - Length of plan's trial period in `trial_units`. `0` means `no trial`.

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18148,11 +18148,14 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of
+            the request then `tax_code` must be absent.
         display_quantity:
           type: boolean
           title: Display quantity?
@@ -18367,14 +18370,14 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part
-            of the request then `tax_code` must be absent.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of
+            the request then `tax_code` must be absent.
         currencies:
           type: array
           title: Add-on pricing
@@ -18522,14 +18525,14 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`. If an `Item` is associated to the
-            `AddOn` then `tax code` must be absent.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes. If an `Item` is associated to the
+            `AddOn` then `tax_code` must be absent.
         display_quantity:
           type: boolean
           title: Display quantity?
@@ -19808,11 +19811,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -19916,11 +19921,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20012,11 +20019,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20466,7 +20475,16 @@ components:
           title: Amount
           description: |
             The amount to be refunded. The amount will be split between the line items.
-            If no amount is specified, it will default to refunding the total refundable amount on the invoice.
+            If `type` is "amount" and no amount is specified, it will default to refunding the total refundable amount on the invoice. Can only be present if `type` is "amount".
+        percentage:
+          type: integer
+          title: Percentage
+          description: The percentage of the remaining balance to be refunded. The
+            percentage will be split between the line items. If `type` is "percentage"
+            and no percentage is specified, it will default to refunding 100% of the
+            refundable amount on the invoice. Can only be present if `type` is "percentage".
+          minimum: 1
+          maximum: 100
         line_items:
           type: array
           title: Line items
@@ -20482,7 +20500,7 @@ components:
             - `all_credit` – Issues credit to the account for the entire amount of the refund. Only available when the Credit Invoices feature is enabled.
             - `all_transaction` – Refunds the entire amount back to transactions, using transactions from previous invoices if necessary. Only available when the Credit Invoices feature is enabled.
           default: credit_first
-          "$ref": "#/components/schemas/RefuneMethodEnum"
+          "$ref": "#/components/schemas/RefundMethodEnum"
         credit_customer_notes:
           type: string
           title: Credit customer notes
@@ -20873,11 +20891,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
         origin_tax_address_source:
@@ -20951,15 +20971,35 @@ components:
         quantity:
           type: integer
           title: Quantity
-          description: Line item quantity to be refunded.
+          description: Line item quantity to be refunded. Must be less than or equal
+            to the `quantity_remaining`. If `quantity_decimal`, `amount`, and `percentage`
+            are not present, `quantity` is required. If `amount` or `percentage` is
+            present, `quantity` must be absent.
         quantity_decimal:
           type: string
           title: Quantity Decimal
-          description: A floating-point alternative to Quantity. If this value is
-            present, it will be used in place of Quantity for calculations, and Quantity
-            will be the rounded integer value of this number. This field supports
-            up to 9 decimal places. The Decimal Quantity feature must be enabled to
-            utilize this field.
+          description: Decimal quantity to refund. The `quantity_decimal` will be
+            used to refund charges that has a NOT null quantity decimal. Must be less
+            than or equal to the `quantity_decimal_remaining`. If `quantity`, `amount`,
+            and `percentage` are not present, `quantity_decimal` is required. If `amount`
+            or `percentage` is present, `quantity_decimal` must be absent. The Decimal
+            Quantity feature must be enabled to utilize this field.
+        amount:
+          type: number
+          format: float
+          description: The specific amount to be refunded from the adjustment. Must
+            be less than or equal to the adjustment's remaining balance. If `quantity`,
+            `quantity_decimal` and `percentage` are not present, `amount` is required.
+            If `quantity`, `quantity_decimal`, or `percentage` is present, `amount`
+            must be absent.
+        percentage:
+          type: integer
+          description: The percentage of the adjustment's remaining balance to refund.
+            If `quantity`, `quantity_decimal` and `amount_in_cents` are not present,
+            `percentage` is required. If `quantity`, `quantity_decimal` or `amount_in_cents`
+            is present, `percentage` must be absent.
+          minimum: 1
+          maximum: 100
         prorate:
           type: boolean
           title: Prorate
@@ -21095,13 +21135,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         product_code:
           type: string
           title: Product code
@@ -21299,11 +21339,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -21512,13 +21554,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -21776,13 +21818,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -26231,8 +26273,9 @@ components:
       type: string
       enum:
       - amount
+      - percentage
       - line_items
-    RefuneMethodEnum:
+    RefundMethodEnum:
       type: string
       enum:
       - all_credit
@@ -26246,6 +26289,7 @@ components:
       - ach
       - amazon
       - apple_pay
+      - braintree_apple_pay
       - check
       - credit_card
       - eft
@@ -26439,6 +26483,7 @@ components:
       - amazon_billing_agreement
       - apple_pay
       - bank_account_info
+      - braintree_apple_pay
       - check
       - credit_card
       - eft

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.52.0",
+  "version": "4.53.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.52.0",
+      "version": "4.53.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
POST /invoices/{invoice_id}/refund
Supports the refunding of:
* an invoice by percentage
* line items by percentage
* line items with amount