### PR TITLE
Generated Latest Changes for v2021-02-25 (add UUID to external subscriptions)

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -1305,6 +1305,10 @@ export declare class ExternalSubscription {
    */
   externalId?: string | null;
   /**
+   * Universally Unique Identifier created automatically.
+   */
+  uuid?: string | null;
+  /**
    * When a new billing event occurred on the external subscription in conjunction with a recent billing period, reactivation or upgrade/downgrade.
    */
   lastPurchased?: Date | null;
@@ -8855,7 +8859,7 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * API docs: https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription
    *
    * 
-   * @param {string} externalSubscriptionId - External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+   * @param {string} externalSubscriptionId - External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
    * @return {Promise<ExternalSubscription>} Settings for an external subscription.
    */
   getExternalSubscription(externalSubscriptionId: string): Promise<ExternalSubscription>;

--- a/lib/recurly/Client.js
+++ b/lib/recurly/Client.js
@@ -2617,7 +2617,7 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * API docs: {@link https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription}
    *
    *
-   * @param {string} externalSubscriptionId - External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+   * @param {string} externalSubscriptionId - External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
    * @return {Promise<ExternalSubscription>} Settings for an external subscription.
    */
   async getExternalSubscription (externalSubscriptionId, options = {}) {

--- a/lib/recurly/resources/ExternalSubscription.js
+++ b/lib/recurly/resources/ExternalSubscription.js
@@ -33,6 +33,7 @@ const Resource = require('../Resource')
  * @prop {Date} trialEndsAt - When the external subscription trial period ends in the external platform.
  * @prop {Date} trialStartedAt - When the external subscription trial period started in the external platform.
  * @prop {Date} updatedAt - When the external subscription was updated in Recurly.
+ * @prop {string} uuid - Universally Unique Identifier created automatically.
  */
 class ExternalSubscription extends Resource {
   static getSchema () {
@@ -57,7 +58,8 @@ class ExternalSubscription extends Resource {
       test: Boolean,
       trialEndsAt: Date,
       trialStartedAt: Date,
-      updatedAt: Date
+      updatedAt: Date,
+      uuid: String
     }
   }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16743,8 +16743,9 @@ components:
     external_subscription_id_fetch:
       name: external_subscription_id
       in: path
-      description: External subscription ID or external_id. For ID no prefix is used
-        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      description: External subscription ID, external_id or uuid. For ID no prefix
+        is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g.
+        `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
       required: true
       schema:
         type: string
@@ -25100,6 +25101,10 @@ components:
           title: External Id
           description: The id of the subscription in the external systems., I.e. Apple
             App Store or Google Play Store.
+        uuid:
+          type: string
+          title: Uuid
+          description: Universally Unique Identifier created automatically.
         last_purchased:
           type: string
           format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.53.0",
+  "version": "4.54.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.53.0",
+      "version": "4.54.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
We are giving the ability to fetch external subscriptions by uuid v3 v2021-02-25

Get `/external_subscriptions/uuid-<uuid_code>` replace <uuid_code> for specific uuid value