### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -3077,6 +3077,10 @@ export declare class Plan {
    */
   taxExempt?: boolean | null;
   /**
+   * Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+   */
+  vertexTransactionType?: string | null;
+  /**
    * Pricing
    */
   currencies?: PlanPricing[] | null;
@@ -5298,6 +5302,10 @@ export interface PlanCreate {
     */
   taxExempt?: boolean | null;
   /**
+    * Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+    */
+  vertexTransactionType?: string | null;
+  /**
     * Pricing
     */
   currencies?: PlanPricing[] | null;
@@ -5673,6 +5681,10 @@ export interface PlanUpdate {
     * `true` exempts tax on the plan, `false` applies tax on the plan.
     */
   taxExempt?: boolean | null;
+  /**
+    * Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+    */
+  vertexTransactionType?: string | null;
   /**
     * Optional when the pricing model is 'ramp'.
     */

--- a/lib/recurly/resources/Plan.js
+++ b/lib/recurly/resources/Plan.js
@@ -43,6 +43,7 @@ const Resource = require('../Resource')
  * @prop {boolean} trialRequiresBillingInfo - Allow free trial subscriptions to be created without billing info. Should not be used if billing info is needed for initial invoice due to existing uninvoiced charges or setup fee.
  * @prop {string} trialUnit - Units for the plan's trial period.
  * @prop {Date} updatedAt - Last updated at
+ * @prop {string} vertexTransactionType - Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
  */
 class Plan extends Resource {
   static getSchema () {
@@ -77,7 +78,8 @@ class Plan extends Resource {
       trialLength: Number,
       trialRequiresBillingInfo: Boolean,
       trialUnit: String,
-      updatedAt: Date
+      updatedAt: Date,
+      vertexTransactionType: String
     }
   }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21353,6 +21353,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21568,6 +21573,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21832,6 +21842,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.55.0",
+  "version": "4.56.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.55.0",
+      "version": "4.56.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
This PR adds the ability to send a plan's `vertex_transaction_type` to vertex. 
 ```
vertex_transaction_type:
  type: string
  title: Vertex Transaction Type
  description: Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
```