### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -461,11 +461,11 @@ export declare class FraudInfo {
 
 export declare class PaymentGatewayReferences {
   /**
-   * Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+   * Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
    */
   token?: string | null;
   /**
-   * The type of reference token. Required if token is passed in for Stripe Gateway.
+   * The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
    */
   referenceType?: string | null;
 
@@ -4375,11 +4375,11 @@ export interface BillingInfoCreate {
 
 export interface PaymentGatewayReferences {
   /**
-    * Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+    * Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
     */
   token?: string | null;
   /**
-    * The type of reference token. Required if token is passed in for Stripe Gateway.
+    * The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
     */
   referenceType?: string | null;
 
@@ -6148,7 +6148,7 @@ export interface SubscriptionCreate {
     */
   trialEndsAt?: Date | null;
   /**
-    * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+    * If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
     */
   startsAt?: Date | null;
   /**
@@ -6845,7 +6845,7 @@ export interface SubscriptionPurchase {
     */
   trialEndsAt?: Date | null;
   /**
-    * If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+    * If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
     */
   startsAt?: Date | null;
   /**

--- a/lib/recurly/resources/PaymentGatewayReferences.js
+++ b/lib/recurly/resources/PaymentGatewayReferences.js
@@ -12,8 +12,8 @@ const Resource = require('../Resource')
 /**
  * PaymentGatewayReferences
  * @typedef {Object} PaymentGatewayReferences
- * @prop {string} referenceType - The type of reference token. Required if token is passed in for Stripe Gateway.
- * @prop {string} token - Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+ * @prop {string} referenceType - The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
+ * @prop {string} token - Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
  */
 class PaymentGatewayReferences extends Resource {
   static getSchema () {

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21322,8 +21322,8 @@ components:
           type: string
           title: Token
           description: Reference value used when the external token was created. If
-            Stripe gateway is used, this value will need to be accompanied by its
-            reference_type.
+            a Stripe gateway or Ebanx gateway is used, this value will need to be
+            accompanied by its reference_type.
         reference_type:
           type: string
           title: Reference Type
@@ -23682,7 +23682,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -23855,7 +23855,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -26564,11 +26564,12 @@ components:
     PaymentGatewayReferencesEnum:
       type: string
       description: The type of reference token. Required if token is passed in for
-        Stripe Gateway.
+        Stripe Gateway or Ebanx UPI.
       enum:
       - stripe_confirmation_token
       - stripe_customer
       - stripe_payment_method
+      - upi_vpa
     GatewayTransactionTypeEnum:
       type: string
       enum:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.59.0",
+  "version": "4.60.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.59.0",
+      "version": "4.60.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
- Adding the new `upi_vpa` payment gateway reference type
- Updated starts_at description to allow backdating subscriptions.