### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/lib/recurly.d.ts
+++ b/lib/recurly.d.ts
@@ -73,7 +73,7 @@ export declare class Address {
    */
   country?: string | null;
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
    */
   geoCode?: string | null;
 
@@ -278,7 +278,7 @@ export declare class ShippingAddress {
    */
   country?: string | null;
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
    */
   geoCode?: string | null;
   /**
@@ -496,6 +496,14 @@ export declare class CustomField {
    * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
    */
   value?: string | null;
+  /**
+   * The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+   */
+  sourceRecordType?: string | null;
+  /**
+   * The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+   */
+  sourceRecordId?: string | null;
 
 }
 
@@ -945,7 +953,7 @@ export declare class AddressWithName {
    */
   country?: string | null;
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
    */
   geoCode?: string | null;
 
@@ -1069,11 +1077,11 @@ export declare class Coupon {
    */
   duration?: string | null;
   /**
-   * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+   * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
    */
   temporalAmount?: number | null;
   /**
-   * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+   * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
    */
   temporalUnit?: string | null;
   /**
@@ -1728,6 +1736,10 @@ export declare class Invoice {
    * Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
    */
   businessEntityId?: string | null;
+  /**
+   * A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
+   */
+  customFields?: CustomField[] | null;
 
 }
 
@@ -1769,7 +1781,7 @@ export declare class InvoiceAddress {
    */
   country?: string | null;
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
    */
   geoCode?: string | null;
   /**
@@ -4354,7 +4366,7 @@ export interface ShippingAddressCreate {
     */
   postalCode?: string | null;
   /**
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     */
   geoCode?: string | null;
   /**
@@ -4394,7 +4406,7 @@ export interface Address {
     */
   country?: string | null;
   /**
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     */
   geoCode?: string | null;
 
@@ -4583,6 +4595,14 @@ export interface CustomField {
     * Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
     */
   value?: string | null;
+  /**
+    * The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+    */
+  sourceRecordType?: string | null;
+  /**
+    * The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+    */
+  sourceRecordId?: string | null;
 
 }
 
@@ -4943,7 +4963,7 @@ export interface ShippingAddressUpdate {
     */
   country?: string | null;
   /**
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     */
   geoCode?: string | null;
 
@@ -5023,11 +5043,11 @@ export interface CouponCreate {
     */
   duration?: string | null;
   /**
-    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
     */
   temporalAmount?: number | null;
   /**
-    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
     */
   temporalUnit?: string | null;
   /**
@@ -5621,7 +5641,7 @@ export interface InvoiceAddress {
     */
   country?: string | null;
   /**
-    * Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+    * Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     */
   geoCode?: string | null;
   /**

--- a/lib/recurly/resources/Address.js
+++ b/lib/recurly/resources/Address.js
@@ -14,7 +14,7 @@ const Resource = require('../Resource')
  * @typedef {Object} Address
  * @prop {string} city - City
  * @prop {string} country - Country, 2-letter ISO 3166-1 alpha-2 code.
- * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+ * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
  * @prop {string} phone - Phone number
  * @prop {string} postalCode - Zip or postal code.
  * @prop {string} region - State or province.

--- a/lib/recurly/resources/AddressWithName.js
+++ b/lib/recurly/resources/AddressWithName.js
@@ -15,7 +15,7 @@ const Resource = require('../Resource')
  * @prop {string} city - City
  * @prop {string} country - Country, 2-letter ISO 3166-1 alpha-2 code.
  * @prop {string} firstName - First name
- * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+ * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
  * @prop {string} lastName - Last name
  * @prop {string} phone - Phone number
  * @prop {string} postalCode - Zip or postal code.

--- a/lib/recurly/resources/Coupon.js
+++ b/lib/recurly/resources/Coupon.js
@@ -35,8 +35,8 @@ const Resource = require('../Resource')
  * @prop {Date} redeemBy - The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
  * @prop {string} redemptionResource - Whether the discount is for all eligible charges on the account, or only a specific subscription.
  * @prop {string} state - Indicates if the coupon is redeemable, and if it is not, why.
- * @prop {number} temporalAmount - If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
- * @prop {string} temporalUnit - If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+ * @prop {number} temporalAmount - If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
+ * @prop {string} temporalUnit - If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
  * @prop {string} uniqueCodeTemplate - On a bulk coupon, the template from which unique coupon codes are generated.
  * @prop {Object} uniqueCouponCode - Will be populated when the Coupon being returned is a `UniqueCouponCode`.
  * @prop {number} uniqueCouponCodesCount - When this number reaches `max_redemptions` the coupon will no longer be redeemable.

--- a/lib/recurly/resources/CustomField.js
+++ b/lib/recurly/resources/CustomField.js
@@ -13,12 +13,16 @@ const Resource = require('../Resource')
  * CustomField
  * @typedef {Object} CustomField
  * @prop {string} name - Fields must be created in the UI before values can be assigned to them.
+ * @prop {string} sourceRecordId - The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+ * @prop {string} sourceRecordType - The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
  * @prop {string} value - Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
  */
 class CustomField extends Resource {
   static getSchema () {
     return {
       name: String,
+      sourceRecordId: String,
+      sourceRecordType: String,
       value: String
     }
   }

--- a/lib/recurly/resources/Invoice.js
+++ b/lib/recurly/resources/Invoice.js
@@ -22,6 +22,7 @@ const Resource = require('../Resource')
  * @prop {Date} createdAt - Created at
  * @prop {Array.<CreditPayment>} creditPayments - Credit payments
  * @prop {string} currency - 3-letter ISO 4217 currency code.
+ * @prop {Array.<CustomField>} customFields - A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
  * @prop {string} customerNotes - This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.
  * @prop {number} discount - Total discounts applied to this invoice.
  * @prop {Date} dueAt - Date invoice is due. This is the date the net terms are reached.
@@ -71,6 +72,7 @@ class Invoice extends Resource {
       createdAt: Date,
       creditPayments: ['CreditPayment'],
       currency: String,
+      customFields: ['CustomField'],
       customerNotes: String,
       discount: Number,
       dueAt: Date,

--- a/lib/recurly/resources/InvoiceAddress.js
+++ b/lib/recurly/resources/InvoiceAddress.js
@@ -16,7 +16,7 @@ const Resource = require('../Resource')
  * @prop {string} company - Company
  * @prop {string} country - Country, 2-letter ISO 3166-1 alpha-2 code.
  * @prop {string} firstName - First name
- * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+ * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
  * @prop {string} lastName - Last name
  * @prop {string} nameOnAccount - Name on account
  * @prop {string} phone - Phone number

--- a/lib/recurly/resources/ShippingAddress.js
+++ b/lib/recurly/resources/ShippingAddress.js
@@ -19,7 +19,7 @@ const Resource = require('../Resource')
  * @prop {Date} createdAt - Created at
  * @prop {string} email
  * @prop {string} firstName
- * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+ * @prop {string} geoCode - Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
  * @prop {string} id - Shipping Address ID
  * @prop {string} lastName
  * @prop {string} nickname

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.73.0",
+  "version": "4.74.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.73.0",
+      "version": "4.74.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).