### PR TITLE
Add HttpAdapter interface for custom HTTP transport injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 coverage/
 .nyc_output/
 docs/
+tmp/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,85 @@ This repository houses the official node library for Recurly's V3 API.
 Docs, Getting Started, and example code can be found here: [https://recurly.github.io/recurly-client-node](https://recurly.github.io/recurly-client-node).
 Documentation for the HTTP API and example code can be found [on our Developer Portal](https://developers.recurly.com/api/v2019-10-10/).
 
+## Custom HTTP Adapter
+
+By default the client uses a built-in HTTP implementation (`DefaultHttpAdapter`) based on Node's `https` module. You can replace it with your own by passing an `httpAdapter` option to the constructor:
+
+```js
+const recurly = require('recurly')
+
+const client = new recurly.Client(apiKey, { httpAdapter: myAdapter })
+```
+
+### HttpAdapter interface
+
+A custom adapter must extend `recurly.HttpAdapter` and implement one method:
+
+```js
+class MyAdapter extends recurly.HttpAdapter {
+  async execute (method, url, headers, body) {
+    // method  — HTTP verb string: 'GET', 'POST', 'PUT', 'DELETE', 'HEAD'
+    // url     — fully-formed URL string, query string already appended
+    // headers — plain object of application-level headers (Authorization, Accept, etc.)
+    // body    — JSON string, or null for requests with no body
+
+    // Must return an HttpResponse:
+    return new recurly.HttpResponse(statusCode, responseHeaders, responseBody)
+    // responseBody must be a decoded string (or null for empty responses)
+  }
+}
+```
+
+The `HttpResponse` constructor normalises header keys to lowercase automatically.
+
+### DefaultHttpAdapter options
+
+`DefaultHttpAdapter` accepts an optional configuration object:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `timeout` | `number` | `60000` | Request timeout in milliseconds. |
+| `logger` | `{ debug(msg) }` | `null` | Optional logger for request lifecycle events. |
+
+```js
+const { DefaultHttpAdapter } = require('recurly')
+
+const adapter = new DefaultHttpAdapter({
+  timeout: 30000,
+  logger: console
+})
+
+const client = new recurly.Client(apiKey, { httpAdapter: adapter })
+```
+
+### HttpMethod constants
+
+```js
+const { HttpMethod } = require('recurly')
+// HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.HEAD
+```
+
+### Gzip
+
+`DefaultHttpAdapter` adds `Accept-Encoding: gzip` automatically and decodes the response. Custom adapters are not required to implement gzip — if you omit the `Accept-Encoding` header the server will respond with uncompressed data and the body will already be a plain string.
+
+### Testing a custom adapter
+
+Use the contract test suite to verify that your adapter satisfies the required behaviours:
+
+```js
+const { HttpAdapterContract } = require('recurly/lib/testing')
+
+describe('MyAdapter', () => {
+  HttpAdapterContract.runSuite(
+    () => new MyAdapter(),
+    ({ name, run }) => it(name, run)
+  )
+})
+```
+
+The suite covers all HTTP methods, header forwarding, status code pass-through, empty body handling, and network failure rejection. It uses a local test server and has no external dependencies.
+
 ## Contributing
 
 Please see our [Contributing Guide](CONTRIBUTING.md).

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -16,4 +16,10 @@ for (let key in resources) {
 
 Schema.locateResource = name => resources[name]
 
+const { HttpAdapter, HttpResponse, HttpMethod } = require('./recurly/HttpAdapter')
+exps.HttpAdapter = HttpAdapter
+exps.HttpResponse = HttpResponse
+exps.HttpMethod = HttpMethod
+exps.DefaultHttpAdapter = require('./recurly/DefaultHttpAdapter')
+
 module.exports = exps

--- a/lib/recurly/BaseClient.js
+++ b/lib/recurly/BaseClient.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const https = require('https')
 const pkg = require('../../package.json')
 const ApiError = require('./ApiError')
 const casters = require('./Caster')
@@ -8,7 +7,9 @@ const querystring = require('querystring')
 const apiErrors = require('./api_errors')
 const utils = require('./utils')
 const resources = require('./resources')
-const { makeRequest } = require('./Http')
+const { Response, Request } = require('./Http')
+const { HttpAdapter } = require('./HttpAdapter')
+const DefaultHttpAdapter = require('./DefaultHttpAdapter')
 
 const BINARY_TYPES = [
   'application/pdf'
@@ -24,7 +25,9 @@ const API_HOSTS = {
  * This is the base functionality for the Recurly.Client.
  * @private
  * @param {string} apiKey - The private api key for the site.
- * @param {string} region - The private region for the site.
+ * @param {Object} [options]
+ * @param {string} [options.region] - API region ('us' or 'eu').
+ * @param {HttpAdapter} [options.httpAdapter] - Custom HTTP adapter. Defaults to DefaultHttpAdapter.
  */
 class BaseClient {
   constructor (apiKey, options = {}) {
@@ -41,21 +44,19 @@ class BaseClient {
       apiHost = API_HOSTS[options.region]
     }
 
-    this._httpOptions = {
-      host: apiHost,
-      port: 443,
-      agent: new https.Agent({
-        keepAlive: true,
-        keepAliveMsecs: 600000,
-        timeout: 10000
-      })
-    }
+    this._apiHost = apiHost
 
-    this._requestAdapter = makeRequest
+    if (options.hasOwnProperty('httpAdapter')) {
+      if (!(options.httpAdapter instanceof HttpAdapter)) {
+        throw new TypeError('options.httpAdapter must be an instance of HttpAdapter')
+      }
+      this._httpAdapter = options.httpAdapter
+    } else {
+      this._httpAdapter = new DefaultHttpAdapter()
+    }
   }
 
   _validatePathParameters (parameters) {
-    // Check to make sure that parameters are valid types
     const invalidTypes = Object.keys(parameters).filter(name => {
       return !['string', 'number', 'bigint'].includes(typeof parameters[name])
     })
@@ -65,7 +66,6 @@ class BaseClient {
       })
       throw new ApiError(`Invalid path parameters: ${issues.join(', ')}`)
     }
-    // Check to make sure that parameters are not empty string values
     const invalidStrings = Object.keys(parameters).filter(name => {
       return typeof parameters[name] === 'string' && parameters[name].trim() === ''
     })
@@ -93,12 +93,17 @@ class BaseClient {
   _makeRequest (method, path, body, options = {}) {
     this._validateOptions(options)
 
-    const reqOptions = this._getRequestOptions(method, path, options)
+    const query = this._buildQuery(options)
+    const url = `https://${this._apiHost}${path}${query}`
+    const headers = this._buildHeaders(options)
+    const bodyStr = body ? JSON.stringify(casters.castRequest(body)) : null
+    const request = new Request(method, path, bodyStr)
 
     return new Promise((resolve, reject) => {
-      const httpReq = this._requestAdapter(reqOptions, body)
-      httpReq
-        .then(recurlyResponse => {
+      this._httpAdapter.execute(method, url, headers, bodyStr)
+        .then(httpResponse => {
+          const recurlyResponse = Response.fromHttpResponse(httpResponse, request)
+
           if (!this['_ignore_deprecation_warning'] && recurlyResponse.apiDeprecated) {
             console.log(`[recurly-client-node] WARNING: Your current API version "${this.apiVersion()}" is deprecated and will be sunset on ${recurlyResponse.apiSunsetDate}`)
           }
@@ -132,7 +137,6 @@ class BaseClient {
     if (!options.params || Object.keys(options.params).length === 0) {
       return ''
     }
-    // The server expects array parameters as CSV strings
     const converted = Object.keys(options.params).reduce((res, key) => {
       if (Array.isArray(options.params[key])) {
         res[key] = options.params[key].join(',')
@@ -145,24 +149,13 @@ class BaseClient {
     return '?' + querystring.stringify(casters.castRequest(converted))
   }
 
-  _getRequestOptions (method, path, options) {
-    // Create a copy to ensure that this._httpOptions is not modified
-    const reqOptions = Object.assign({}, this._httpOptions)
-    reqOptions.method = method
-    reqOptions.path = path + this._buildQuery(options)
-
-    // The headers can't be stored in _httpOptions because this object will
-    // be directly modified for certain requests. Object.assign() does not allow
-    // for deep cloning
-    reqOptions.headers = Object.assign({}, options.headers, {
+  _buildHeaders (options = {}) {
+    return Object.assign({}, options.headers, {
       'Accept': `application/vnd.recurly.${this.apiVersion()}`,
       'User-Agent': `Recurly/${pkg.version}; node ${process.version}`,
       'Authorization': 'Basic ' + Buffer.from(this._getApiKey() + ':', 'ascii').toString('base64'),
-      'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6',
       'Content-Type': 'application/json; charset=utf-8'
     })
-
-    return reqOptions
   }
 
   /**
@@ -175,9 +168,9 @@ class BaseClient {
 
     if (resp.status < 200 || resp.status > 299) {
       if (jsonContent && resp.body) {
-        const errBody = resp.body && JSON.parse(resp.body).error
-        // If we have a body, we determine the error based on
-        // the contents of the body
+        const errBody = typeof resp.body === 'string'
+          ? JSON.parse(resp.body).error
+          : resp.body.error
         if (errBody) {
           let className = utils.classify(errBody.type)
           if (!className.endsWith('Error')) className += 'Error'
@@ -194,8 +187,6 @@ class BaseClient {
           err._setResponse(resp)
           return err
         }
-      // if we don't have a JSON body, we determine the error
-      // based on the http status code
       } else {
         if (resp.status in apiErrors.ERROR_MAP) {
           const ErrClass = apiErrors.ERROR_MAP[resp.status]

--- a/lib/recurly/DefaultHttpAdapter.d.ts
+++ b/lib/recurly/DefaultHttpAdapter.d.ts
@@ -1,0 +1,20 @@
+import { HttpAdapter, HttpResponse } from './HttpAdapter';
+
+export interface DefaultHttpAdapterLogger {
+  debug(message: string): void;
+}
+
+export interface DefaultHttpAdapterOptions {
+  timeout?: number;
+  logger?: DefaultHttpAdapterLogger | null;
+}
+
+export default class DefaultHttpAdapter extends HttpAdapter {
+  constructor(options?: DefaultHttpAdapterOptions);
+  execute(
+    method: string,
+    url: string,
+    headers: Record<string, string>,
+    body: string | null
+  ): Promise<HttpResponse>;
+}

--- a/lib/recurly/DefaultHttpAdapter.js
+++ b/lib/recurly/DefaultHttpAdapter.js
@@ -1,0 +1,144 @@
+'use strict'
+
+const https = require('https')
+const http = require('http')
+const zlib = require('zlib')
+const { URL } = require('url')
+const { HttpAdapter, HttpResponse } = require('./HttpAdapter')
+const apiErrors = require('./api_errors')
+
+const ZLIB_OPTIONS = {
+  flush: zlib.Z_SYNC_FLUSH,
+  finishFlush: zlib.Z_SYNC_FLUSH
+}
+
+const BINARY_CONTENT_TYPES = ['application/pdf']
+
+function isBinaryContentType (contentType) {
+  return BINARY_CONTENT_TYPES.some(t => (contentType || '').includes(t))
+}
+
+function responseEncoding (contentType) {
+  return isBinaryContentType(contentType) ? 'binary' : 'utf-8'
+}
+
+/**
+ * Default HTTP adapter. Uses Node's built-in https/http modules.
+ *
+ * Owns:
+ * - Accept-Encoding: gzip negotiation and response body decompression
+ * - Content-Length header
+ * - Keep-alive connection management via https.Agent
+ * - Timeout and ECONNRESET retry
+ *
+ * @param {Object} [options]
+ * @param {number} [options.timeout=60000] - Request timeout in milliseconds.
+ * @param {{ debug: function(string): void }|null} [options.logger=null] - Optional logger for request lifecycle events.
+ */
+class DefaultHttpAdapter extends HttpAdapter {
+  constructor ({ timeout = 60000, logger = null } = {}) {
+    super()
+    this._timeout = timeout
+    this._logger = logger
+    this._agents = {
+      'https:': new https.Agent({
+        keepAlive: true,
+        keepAliveMsecs: 600000,
+        timeout: 10000
+      }),
+      'http:': new http.Agent({
+        keepAlive: true,
+        keepAliveMsecs: 600000,
+        timeout: 10000
+      })
+    }
+  }
+
+  execute (method, url, headers, body) {
+    if (this._logger) this._logger.debug(`[recurly] ${method} ${url}`)
+    const parsed = new URL(url)
+    const isHttps = parsed.protocol === 'https:'
+    const transport = isHttps ? https : http
+
+    const reqHeaders = Object.assign({}, headers, {
+      'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6'
+    })
+
+    if (body) {
+      reqHeaders['Content-Length'] = Buffer.byteLength(body)
+    }
+
+    const reqOptions = {
+      hostname: parsed.hostname,
+      port: parsed.port || (isHttps ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method: method,
+      headers: reqHeaders,
+      agent: this._agents[parsed.protocol]
+    }
+
+    return new Promise((resolve, reject) => {
+      let aborted = false
+
+      const submitRequest = () => {
+        const httpRequest = transport.request(reqOptions, (httpResponse) => {
+          const rawHeaders = httpResponse.headers
+
+          const contentEncoding = (rawHeaders['content-encoding'] || '').toLowerCase()
+          const contentType = rawHeaders['content-type'] || ''
+          const encoding = responseEncoding(contentType)
+
+          let responseStream
+          if (contentEncoding === 'gzip') {
+            responseStream = zlib.createGunzip(ZLIB_OPTIONS)
+            httpResponse.pipe(responseStream)
+          } else if (contentEncoding === 'deflate') {
+            responseStream = zlib.createInflate(ZLIB_OPTIONS)
+            httpResponse.pipe(responseStream)
+          } else {
+            responseStream = httpResponse
+          }
+
+          responseStream.setEncoding(encoding)
+
+          const chunks = []
+          responseStream.on('data', chunk => chunks.push(chunk))
+          responseStream.on('end', () => {
+            const bodyStr = chunks.join('')
+            resolve(new HttpResponse(
+              httpResponse.statusCode,
+              rawHeaders,
+              bodyStr
+            ))
+          })
+          responseStream.on('error', reject)
+        })
+
+        httpRequest.setTimeout(this._timeout, () => {
+          aborted = true
+          httpRequest.destroy()
+          reject(new apiErrors.TimeoutError('Request timed out', 'timeout_error'))
+        })
+
+        httpRequest.on('error', (err) => {
+          if (aborted) return
+          if (!reqOptions.retried && err.code === 'ECONNRESET') {
+            reqOptions.retried = true
+            submitRequest()
+          } else {
+            reject(err)
+          }
+        })
+
+        if (body) {
+          httpRequest.write(body)
+        }
+        httpRequest.end()
+      }
+
+      submitRequest()
+    })
+  }
+}
+
+module.exports = DefaultHttpAdapter

--- a/lib/recurly/Http.js
+++ b/lib/recurly/Http.js
@@ -1,100 +1,11 @@
-const https = require('https')
-const zlib = require('zlib')
-const casters = require('./Caster')
-const apiErrors = require('./api_errors')
-
-const BINARY_TYPES = [
-  'application/pdf'
-]
-const TIMEOUT = 60000
-
-const ZLIB_OPTIONS = {
-  flush: zlib.Z_SYNC_FLUSH,
-  finishFlush: zlib.Z_SYNC_FLUSH
-}
-
-function responseEncoding (contentType = '') {
-  const isBinary = BINARY_TYPES.find((binaryType) => contentType.includes(binaryType))
-  return isBinary ? 'binary' : 'utf-8'
-}
-
-// an adapter function to abstract away some of
-// the low level details of requests and responses in node
-function makeRequest (options, requestBody) {
-  if (requestBody) {
-    requestBody = JSON.stringify(casters.castRequest(requestBody))
-    options.headers['Content-Length'] = Buffer.byteLength(requestBody)
-  }
-  return new Promise((resolve, reject) => {
-    let aborted = false
-
-    const submitRequest = () => {
-      const httpRequest = https.request(options, (httpResponse) => {
-        // downcase response headers
-        const responseHeaders = {}
-        for (const header in httpResponse.headers) {
-          responseHeaders[header.toLowerCase()] = httpResponse.headers[header]
-        }
-
-        var responseStream
-        const encoding = responseHeaders['content-encoding']
-
-        if (encoding === 'gzip') {
-          responseStream = zlib.createGunzip(ZLIB_OPTIONS)
-          httpResponse.pipe(responseStream)
-        } else if (encoding === 'deflate') {
-          responseStream = zlib.createInflate(ZLIB_OPTIONS)
-          httpResponse.pipe(responseStream)
-        } else {
-          responseStream = httpResponse
-        }
-        responseStream.setEncoding(responseEncoding(responseHeaders['content-type']))
-
-        const chunks = []
-        responseStream.on('data', chunk => chunks.push(chunk))
-        responseStream.on('end', () => {
-          const rbody = chunks.join('')
-
-          const recurlyRequest = new Request(options.method, options.path, requestBody)
-          const recurlyResponse = Response.build(httpResponse, rbody, recurlyRequest)
-          resolve(recurlyResponse)
-        })
-      })
-      httpRequest.setTimeout(TIMEOUT, () => {
-        aborted = true
-        httpRequest.abort()
-        reject(new apiErrors.TimeoutError('Timeout while sending request', 'timeout_error'))
-      })
-      httpRequest.on('error', (err) => {
-        if (aborted) {
-          return
-        }
-
-        // when using keep-alive, we need to retry requests if the socket is reset
-        // https://nodejs.org/api/http.html#http_request_reusedsocket
-        if (!options.retried && err.code === 'ECONNRESET') {
-          options.retried = true
-          submitRequest()
-        } else {
-          reject(err)
-        }
-      })
-      if (requestBody) {
-        httpRequest.write(requestBody)
-      }
-      httpRequest.end()
-    }
-
-    submitRequest()
-  })
-}
+'use strict'
 
 /**
  * This class contains the metadata from the HTTP response
  * from Recurly.
  * @property {Request} request - The request responsible for this response.
- * @property {Object} body - The parsed JSON response body.
- * @property {number} statusCode - The HTTP status code.
+ * @property {string|null} body - The raw response body string.
+ * @property {number} status - The HTTP status code.
  * @property {string} contentType - The HTTP content type.
  * @property {string} requestId - The unique id Recurly assigned to this request. Keep this for support.
  * @property {number} rateLimit - The max rate limit.
@@ -106,42 +17,43 @@ function makeRequest (options, requestBody) {
  * @property {Object} proxyMetadata - Metadata from the proxy (e.g. cloudflare). Can be useful for debugging.
  */
 class Response {
-  static build (response, body, request) {
+  /**
+   * Build a Response from an HttpResponse value object returned by an HttpAdapter.
+   *
+   * @param {import('./HttpAdapter').HttpResponse} httpResponse
+   * @param {Request} request
+   * @return {Response}
+   */
+  static fromHttpResponse (httpResponse, request) {
     const resp = new Response()
-    resp.request = request
-    resp.body = null
-    if (body && body.length > 0) {
-      resp.body = body
-    }
-    // downcase response headers
-    const responseHeaders = {}
-    for (const header in response.headers) {
-      responseHeaders[header.toLowerCase()] = response.headers[header]
-    }
-    resp.status = response.statusCode
-    resp.requestId = responseHeaders['x-request-id']
-    resp.rateLimit = parseInt(responseHeaders['x-ratelimit-limit'], 10)
-    resp.rateLimitRemaining = parseInt(responseHeaders['x-ratelimit-remaining'], 10)
-    resp.rateLimitReset = new Date(parseInt(responseHeaders['x-ratelimit-reset'], 10) * 1000)
-    if (responseHeaders['content-type']) {
-      resp.contentType = responseHeaders['content-type'].split(';')[0]
-    }
-    resp.recordCount = null
-    resp.apiDeprecated = false
-    resp.apiSunsetDate = null
-    const deprecated = responseHeaders['recurly-deprecated'] || ''
-    if (deprecated.toUpperCase() === 'TRUE') {
-      resp.apiDeprecated = true
-      resp.apiSunsetDate = responseHeaders['recurly-sunset-date']
-    }
+    const h = httpResponse.headers // already lowercased by HttpResponse constructor
 
-    if (responseHeaders['recurly-total-records']) {
-      resp.recordCount = parseInt(responseHeaders['recurly-total-records'], 10)
-    }
-    resp.date = responseHeaders['date']
+    resp.request = request
+    resp.body = httpResponse.body
+    resp.status = httpResponse.statusCode
+
+    resp.requestId = h['x-request-id'] || null
+    resp.rateLimit = parseInt(h['x-ratelimit-limit'], 10) || null
+    resp.rateLimitRemaining = parseInt(h['x-ratelimit-remaining'], 10) || null
+    resp.rateLimitReset = h['x-ratelimit-reset']
+      ? new Date(parseInt(h['x-ratelimit-reset'], 10) * 1000)
+      : null
+
+    resp.contentType = h['content-type']
+      ? h['content-type'].split(';')[0].trim()
+      : null
+
+    resp.recordCount = h['recurly-total-records']
+      ? parseInt(h['recurly-total-records'], 10)
+      : null
+
+    resp.apiDeprecated = (h['recurly-deprecated'] || '').toUpperCase() === 'TRUE'
+    resp.apiSunsetDate = resp.apiDeprecated ? (h['recurly-sunset-date'] || null) : null
+
+    resp.date = h['date'] || null
     resp.proxyMetadata = {
-      'server': responseHeaders['server'],
-      'cf-ray': responseHeaders['cf-ray']
+      server: h['server'] || null,
+      'cf-ray': h['cf-ray'] || null
     }
 
     return resp
@@ -156,7 +68,7 @@ class Request {
   /**
    * @param {string} method - The HTTP method of the request.
    * @param {string} path - The path of the request.
-   * @param {Object} body - The JSON body of the request (optional).
+   * @param {string|null} body - The JSON body of the request (optional).
    */
   constructor (method, path, body = null) {
     this.method = method.toUpperCase()
@@ -165,6 +77,5 @@ class Request {
   }
 }
 
-module.exports.makeRequest = makeRequest
 module.exports.Response = Response
 module.exports.Request = Request

--- a/lib/recurly/HttpAdapter.d.ts
+++ b/lib/recurly/HttpAdapter.d.ts
@@ -1,0 +1,23 @@
+export class HttpResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string | null;
+  constructor(statusCode: number, headers: Record<string, string>, body: string | null | undefined);
+}
+
+export abstract class HttpAdapter {
+  execute(
+    method: string,
+    url: string,
+    headers: Record<string, string>,
+    body: string | null
+  ): Promise<HttpResponse>;
+}
+
+export const HttpMethod: {
+  readonly GET: 'GET';
+  readonly POST: 'POST';
+  readonly PUT: 'PUT';
+  readonly DELETE: 'DELETE';
+  readonly HEAD: 'HEAD';
+};

--- a/lib/recurly/HttpAdapter.js
+++ b/lib/recurly/HttpAdapter.js
@@ -1,0 +1,64 @@
+'use strict'
+
+/**
+ * Value object returned by every HttpAdapter implementation.
+ * The constructor normalizes all response header keys to lowercase so the SDK
+ * can read them consistently regardless of what the server or adapter sends.
+ *
+ * @property {number} statusCode - HTTP status code (e.g. 200, 404).
+ * @property {Object} headers - Response headers, all keys lowercased.
+ * @property {string|null} body - Fully buffered, gzip-decoded response body, or null for empty responses.
+ */
+class HttpResponse {
+  constructor (statusCode, headers, body) {
+    this.statusCode = statusCode
+    this.headers = Object.keys(headers || {}).reduce((acc, k) => {
+      acc[k.toLowerCase()] = headers[k]
+      return acc
+    }, {})
+    this.body = (body !== null && body !== undefined && body !== '') ? body : null
+  }
+}
+
+/**
+ * Abstract base class for HTTP adapters.
+ *
+ * Implement `execute` to provide a custom HTTP transport. Inject the adapter
+ * via `new Client(apiKey, { httpAdapter: adapter })`.
+ *
+ * Contract:
+ * - Throw / reject only on transport failures (timeout, DNS, connection refused).
+ * - Return HTTP 4xx/5xx as a normal HttpResponse — the SDK decides what's an error.
+ * - The response body must always be gzip-decoded before returning.
+ * - The SDK owns auth, accept, content-type, and idempotency headers.
+ * - The adapter owns Accept-Encoding, Content-Length, and connection management.
+ */
+class HttpAdapter {
+  /**
+   * Execute an HTTP request.
+   *
+   * @param {string} method - HTTP method (use HttpMethod constants).
+   * @param {string} url - Fully-formed URL; query string already serialized by SDK.
+   * @param {Object} headers - Request headers provided by the SDK (lowercase keys).
+   * @param {string|null} body - JSON-serialized request body, or null for no body.
+   * @return {Promise<HttpResponse>}
+   */
+  execute (method, url, headers, body) {
+    throw new Error('HttpAdapter.execute() must be implemented by subclass')
+  }
+}
+
+/**
+ * Named HTTP method constants. The SDK passes one of these to HttpAdapter.execute().
+ */
+const HttpMethod = Object.freeze({
+  GET: 'GET',
+  POST: 'POST',
+  PUT: 'PUT',
+  DELETE: 'DELETE',
+  HEAD: 'HEAD'
+})
+
+module.exports.HttpResponse = HttpResponse
+module.exports.HttpAdapter = HttpAdapter
+module.exports.HttpMethod = HttpMethod

--- a/lib/recurly/HttpAdapterContract.js
+++ b/lib/recurly/HttpAdapterContract.js
@@ -1,0 +1,240 @@
+'use strict'
+
+const http = require('http')
+const assert = require('assert').strict
+
+/**
+ * Creates and starts a local HTTP server for testing.
+ * The server responds to each request based on the provided handler.
+ *
+ * @param {Function} handler - (req, res) handler function.
+ * @return {Promise<http.Server>} Resolves when the server is listening.
+ */
+function startServer (handler) {
+  return new Promise((resolve) => {
+    const sockets = new Set()
+    const server = http.createServer(handler)
+    server.on('connection', (sock) => {
+      sockets.add(sock)
+      sock.once('close', () => sockets.delete(sock))
+    })
+    server._sockets = sockets
+    server.listen(0, '127.0.0.1', () => resolve(server))
+  })
+}
+
+function stopServer (server) {
+  return new Promise((resolve, reject) => {
+    if (server._sockets) {
+      server._sockets.forEach(s => s.destroy())
+    }
+    server.close(err => err ? reject(err) : resolve())
+  })
+}
+
+function serverUrl (server) {
+  const { address, port } = server.address()
+  return `http://${address}:${port}`
+}
+
+/**
+ * Runs the HttpAdapter contract test suite against a given adapter instance.
+ *
+ * Each test is registered via the `register` callback, which receives `{ name, run }`.
+ * `name` is the test description; `run` is an async function that asserts the behaviour.
+ *
+ * Example with mocha:
+ *
+ *   const { HttpAdapterContract } = require('recurly/lib/testing')
+ *   describe('MyAdapter', () => {
+ *     HttpAdapterContract.runSuite(() => new MyAdapter(), ({ name, run }) => it(name, run))
+ *   })
+ *
+ * @param {Function} createAdapter - Factory that returns a fresh HttpAdapter for each test.
+ * @param {Function} register - Called once per test with `{ name: string, run: Function }`.
+ */
+function runSuite (createAdapter, register) {
+  register({
+    name: 'GET — request reaches server and response is returned',
+    run: async () => {
+      let receivedMethod
+      const server = await startServer((req, res) => {
+        receivedMethod = req.method
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end('{"ok":true}')
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      const resp = await adapter.execute('GET', `${base}/test`, {}, null)
+      await stopServer(server)
+      assert.equal(receivedMethod, 'GET')
+      assert.equal(resp.statusCode, 200)
+      assert.equal(resp.body, '{"ok":true}')
+    }
+  })
+
+  register({
+    name: 'POST — sends body to server',
+    run: async () => {
+      let receivedBody = ''
+      const server = await startServer((req, res) => {
+        req.on('data', c => { receivedBody += c })
+        req.on('end', () => {
+          res.writeHead(201, { 'content-type': 'application/json' })
+          res.end('{"created":true}')
+        })
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      await adapter.execute('POST', `${base}/items`, { 'content-type': 'application/json' }, '{"name":"test"}')
+      await stopServer(server)
+      assert.equal(receivedBody, '{"name":"test"}')
+    }
+  })
+
+  register({
+    name: 'PUT — sends body to server',
+    run: async () => {
+      let receivedMethod
+      let receivedBody = ''
+      const server = await startServer((req, res) => {
+        receivedMethod = req.method
+        req.on('data', c => { receivedBody += c })
+        req.on('end', () => {
+          res.writeHead(200, {})
+          res.end('')
+        })
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      await adapter.execute('PUT', `${base}/items/1`, {}, '{"name":"updated"}')
+      await stopServer(server)
+      assert.equal(receivedMethod, 'PUT')
+      assert.equal(receivedBody, '{"name":"updated"}')
+    }
+  })
+
+  register({
+    name: 'DELETE — sends no body',
+    run: async () => {
+      let receivedBody = ''
+      const server = await startServer((req, res) => {
+        req.on('data', c => { receivedBody += c })
+        req.on('end', () => {
+          res.writeHead(200, {})
+          res.end('')
+        })
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      await adapter.execute('DELETE', `${base}/items/1`, {}, null)
+      await stopServer(server)
+      assert.equal(receivedBody, '')
+    }
+  })
+
+  register({
+    name: 'HEAD — returns empty body',
+    run: async () => {
+      const server = await startServer((req, res) => {
+        res.writeHead(200, { 'x-total': '42' })
+        res.end()
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      const resp = await adapter.execute('HEAD', `${base}/items`, {}, null)
+      await stopServer(server)
+      assert.equal(resp.statusCode, 200)
+      assert.equal(resp.body, null)
+    }
+  })
+
+  register({
+    name: 'Request headers — forwarded to server unmodified',
+    run: async () => {
+      let receivedHeaders
+      const server = await startServer((req, res) => {
+        receivedHeaders = req.headers
+        res.writeHead(200, {})
+        res.end('')
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      await adapter.execute('GET', `${base}/test`, {
+        'authorization': 'Basic abc123',
+        'accept': 'application/json',
+        'x-custom-header': 'myvalue'
+      }, null)
+      await stopServer(server)
+      assert.equal(receivedHeaders['authorization'], 'Basic abc123')
+      assert.equal(receivedHeaders['accept'], 'application/json')
+      assert.equal(receivedHeaders['x-custom-header'], 'myvalue')
+    }
+  })
+
+  register({
+    name: 'Response headers — keys are normalized to lowercase',
+    run: async () => {
+      const server = await startServer((req, res) => {
+        res.writeHead(200, { 'X-Request-Id': 'abc', 'Content-Type': 'application/json' })
+        res.end('{}')
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      const resp = await adapter.execute('GET', `${base}/test`, {}, null)
+      await stopServer(server)
+      assert.equal(resp.headers['x-request-id'], 'abc')
+      assert.equal(resp.headers['content-type'], 'application/json')
+    }
+  })
+
+  const STATUS_CODES = [200, 201, 204, 400, 404, 422, 500]
+  for (const status of STATUS_CODES) {
+    register({
+      name: `Status ${status} — returned as-is without translation`,
+      run: async () => {
+        const server = await startServer((req, res) => {
+          res.writeHead(status, {})
+          res.end('')
+        })
+        const adapter = createAdapter()
+        const base = serverUrl(server)
+        const resp = await adapter.execute('GET', `${base}/test`, {}, null)
+        await stopServer(server)
+        assert.equal(resp.statusCode, status)
+      }
+    })
+  }
+
+  register({
+    name: '204 — body is null',
+    run: async () => {
+      const server = await startServer((req, res) => {
+        res.writeHead(204, {})
+        res.end()
+      })
+      const adapter = createAdapter()
+      const base = serverUrl(server)
+      const resp = await adapter.execute('DELETE', `${base}/items/1`, {}, null)
+      await stopServer(server)
+      assert.equal(resp.statusCode, 204)
+      assert.equal(resp.body, null)
+    }
+  })
+
+  register({
+    name: 'Network failure — rejected with error on closed port',
+    run: async () => {
+      const adapter = createAdapter()
+      // Port 1 is reserved/unreachable; connecting should reject
+      try {
+        await adapter.execute('GET', 'http://127.0.0.1:1/test', {}, null)
+        assert.fail('Expected execute() to reject on network failure')
+      } catch (err) {
+        assert.ok(err instanceof Error)
+      }
+    }
+  })
+}
+
+module.exports.runSuite = runSuite

--- a/lib/testing.js
+++ b/lib/testing.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { HttpAdapter, HttpResponse, HttpMethod } = require('./recurly/HttpAdapter')
+const DefaultHttpAdapter = require('./recurly/DefaultHttpAdapter')
+const { runSuite } = require('./recurly/HttpAdapterContract')
+
+module.exports = {
+  HttpAdapter,
+  HttpResponse,
+  HttpMethod,
+  DefaultHttpAdapter,
+  HttpAdapterContract: { runSuite }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recurly",
-  "version": "4.78.0",
+  "version": "4.79.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recurly",
-      "version": "4.78.0",
+      "version": "4.79.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^12.11.1",

--- a/scripts/test
+++ b/scripts/test
@@ -12,5 +12,5 @@ if [ "$1" = "--watch" ]; then
 else
   node $NODE_FLAGS ./node_modules/.bin/standard "lib/**/*.js" "test/**/*.js" && \
   ./node_modules/.bin/nyc --reporter=html node $NODE_FLAGS ./node_modules/.bin/_mocha --recursive && \
-  ./node_modules/.bin/tsc lib/recurly.d.ts
+  ./node_modules/.bin/tsc lib/recurly.d.ts lib/recurly/HttpAdapter.d.ts lib/recurly/DefaultHttpAdapter.d.ts
 fi

--- a/test/http_test_helpers.js
+++ b/test/http_test_helpers.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { HttpResponse } = require('../lib/recurly/HttpAdapter')
+
+function jsonResponse (status, obj) {
+  const body = obj !== null ? JSON.stringify(obj) : null
+  return Promise.resolve(new HttpResponse(status, { 'content-type': 'application/json; charset=utf-8' }, body))
+}
+
+function emptyResponse (status) {
+  return Promise.resolve(new HttpResponse(status, {}, null))
+}
+
+module.exports = { HttpResponse, jsonResponse, emptyResponse }

--- a/test/integration/httpAdapter.test.js
+++ b/test/integration/httpAdapter.test.js
@@ -1,0 +1,36 @@
+/* globals describe, it, before */
+
+'use strict'
+
+const assert = require('assert').strict
+const recurly = require('../../lib/recurly')
+
+const API_KEY = process.env.RECURLY_API_KEY
+
+describe('HttpAdapter integration', function () {
+  before(function () {
+    if (!API_KEY) this.skip()
+  })
+
+  it('custom adapter is injected and used for a real API call', async function () {
+    this.timeout(10000)
+
+    let executeCalled = false
+
+    class TrackingAdapter extends recurly.DefaultHttpAdapter {
+      execute (method, url, headers, body) {
+        executeCalled = true
+        return super.execute(method, url, headers, body)
+      }
+    }
+
+    const client = new recurly.Client(API_KEY, {
+      httpAdapter: new TrackingAdapter()
+    })
+
+    const count = await client.listAccounts({ params: { limit: 1 } }).count()
+
+    assert.ok(typeof count === 'number', 'count() should return a number')
+    assert.ok(executeCalled, 'adapter.execute() should have been called')
+  })
+})

--- a/test/mock_client.js
+++ b/test/mock_client.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon')
 const BaseClient = require('../lib/recurly/BaseClient')
 const Pager = require('../lib/recurly/Pager')
-const { Request, Response } = require('../lib/recurly/Http')
+const { HttpResponse } = require('../lib/recurly/HttpAdapter')
 
 class MockClient extends BaseClient {
   constructor (apiKey, options = {}) {
@@ -44,26 +44,23 @@ class MockClient extends BaseClient {
   }
 
   mock (strategy) {
-    this._sandbox.stub(this, '_requestAdapter').callsFake((options, requestBody) => {
-      const req = new Request(options.method, options.path, requestBody)
-      const resp = new Response()
-      resp.request = req
-      resp.contentType = 'application/json'
-      return strategy(resp, options)
-    })
+    this._sandbox.stub(this._httpAdapter, 'execute').callsFake(strategy)
   }
 
   restore () {
     this._sandbox.restore()
   }
 
-  calledWith (options, body) {
-    return this._requestAdapter.calledWithMatch(options, body)
+  calledWith (method, urlMatcher, headers, body) {
+    const h = headers !== undefined ? headers : sinon.match.any
+    const b = body !== undefined ? body : sinon.match.any
+    return this._httpAdapter.execute.calledWithMatch(method, urlMatcher, h, b)
   }
 
   callCount () {
-    return this._requestAdapter.callCount
+    return this._httpAdapter.execute.callCount
   }
 }
 
-module.exports = MockClient
+module.exports.MockClient = MockClient
+module.exports.HttpResponse = HttpResponse

--- a/test/recurly/BaseClient.test.js
+++ b/test/recurly/BaseClient.test.js
@@ -5,38 +5,46 @@ const sinon = require('sinon')
 const { MyResource } = require('../mock_resources')
 const assert = require('assert').strict
 const recurly = require('../../lib/recurly')
-const MockClient = require('../mock_client')
+const { MockClient } = require('../mock_client')
+const { jsonResponse, emptyResponse } = require('../http_test_helpers')
 
 const client = new MockClient('myapikey')
 
 describe('BaseClient', () => {
   afterEach(() => {
-    // completely restore all fakes
     client.restore()
   })
 
   describe('#constructor', () => {
     it('Should set the internal state and headers', () => {
-      assert.equal(client._getRequestOptions('GET', '/resources', {}).headers['Authorization'], 'Basic bXlhcGlrZXk6')
+      const headers = client._buildHeaders({})
+      assert.equal(headers['Authorization'], 'Basic bXlhcGlrZXk6')
       const userAgentRegex = /^Recurly\/\d+(\.\d+){0,2}; node v\d+(\.\d+){0,2}.*$/
-      assert.ok(userAgentRegex.test(client._getRequestOptions('GET', '/resources', {}).headers['User-Agent']))
-      assert.equal(client._getRequestOptions('GET', '/resources', {}).headers['Accept'], 'application/vnd.recurly.v2022-01-01')
+      assert.ok(userAgentRegex.test(headers['User-Agent']))
+      assert.equal(headers['Accept'], 'application/vnd.recurly.v2022-01-01')
     })
 
     it('should set host to EU DataCenter', () => {
-      const clientEU = new MockClient('myapikey', { 'region': 'eu' })
-      assert.equal(clientEU._httpOptions.host, 'v3.eu.recurly.com')
+      const clientEU = new MockClient('myapikey', { region: 'eu' })
+      assert.equal(clientEU._apiHost, 'v3.eu.recurly.com')
     })
 
     it('should set host to US DataCenter', () => {
-      assert.equal(client._httpOptions.host, 'v3.recurly.com')
+      assert.equal(client._apiHost, 'v3.recurly.com')
     })
 
     it('should validate that region is an invalid value', () => {
-      assert.throws(() => {
-        const invalidClient = new MockClient('myapikey', { 'region': 'none' })
-        assert.equal(invalidClient._httpOptions.host, '')
-      }, recurly.ApiError)
+      assert.throws(() => new MockClient('myapikey', { region: 'none' }), recurly.ApiError)
+    })
+
+    it('should accept a custom httpAdapter', () => {
+      const adapter = new recurly.HttpAdapter()
+      const customClient = new MockClient('myapikey', { httpAdapter: adapter })
+      assert.equal(customClient._httpAdapter, adapter)
+    })
+
+    it('should throw when httpAdapter is not an HttpAdapter instance', () => {
+      assert.throws(() => new MockClient('myapikey', { httpAdapter: {} }), TypeError)
     })
   })
 
@@ -74,10 +82,8 @@ describe('BaseClient', () => {
 
   describe('#_makeRequest', () => {
     beforeEach(() => {
-      client.mock((resp, options) => {
-        resp.status = 200
-        resp.body = JSON.stringify({ id: 'myid', object: 'my_resource' })
-        return Promise.resolve(resp)
+      client.mock((method, url, headers, body) => {
+        return jsonResponse(200, { id: 'myid', object: 'my_resource' })
       })
     })
 
@@ -112,46 +118,31 @@ describe('BaseClient', () => {
 
   describe('with mocked request adapter', () => {
     beforeEach(() => {
-      client.mock((resp, options) => {
-        if (options.path === '/resources/myid') {
-          resp.status = 200
-          resp.body = JSON.stringify({ id: 'myid', object: 'my_resource' })
-        } else if (options.path === '/resources' && options.method === 'POST') {
-          resp.status = 422
-          resp.body = JSON.stringify({ error: { type: 'transaction' } })
+      client.mock((method, url, headers, body) => {
+        if (url.includes('/resources/myid')) {
+          return jsonResponse(200, { id: 'myid', object: 'my_resource' })
+        } else if (url.includes('/resources') && method === 'POST') {
+          return jsonResponse(422, { error: { type: 'transaction' } })
         } else {
-          resp.status = 404
-          resp.body = JSON.stringify({ error: { type: 'not_found' } })
+          return jsonResponse(404, { error: { type: 'not_found' } })
         }
-        return Promise.resolve(resp)
       })
     })
 
     describe('#getResource', () => {
       it('Should return a resource given a valid id', () => {
-        const resp = client.getResource('myid')
-        return resp
+        return client.getResource('myid')
           .then(resource => {
             assert(resource instanceof MyResource)
-
-            let options = sinon.match({
-              method: 'GET',
-              path: '/resources/myid'
-            })
-            assert(client.calledWith(options, null))
+            assert(client.calledWith('GET', sinon.match('/resources/myid')))
           })
       })
+
       it('Should throw a NotFoundError given an invalid id', () => {
-        const resp = client.getResource('idontexist')
-        return resp
+        return client.getResource('idontexist')
           .catch(err => {
             assert(err instanceof recurly.errors.NotFoundError)
-
-            let options = sinon.match({
-              method: 'GET',
-              path: '/resources/idontexist'
-            })
-            assert(client.calledWith(options, null))
+            assert(client.calledWith('GET', sinon.match('/resources/idontexist')))
           })
       })
     })
@@ -159,136 +150,91 @@ describe('BaseClient', () => {
     describe('#createResource', () => {
       describe('When details are invalid', () => {
         it('Should throw a TransactionError', () => {
-          const resp = client.createResource({ myString: 'test' })
-          return resp
+          return client.createResource({ myString: 'test' })
             .catch(err => {
               assert(err instanceof recurly.errors.TransactionError)
-
-              let options = sinon.match({
-                method: 'POST',
-                path: '/resources'
-              })
-
-              assert(client.calledWith(options, { myString: 'test' }))
+              assert(client.calledWith('POST', sinon.match('/resources')))
             })
         })
       })
     })
   })
 
+  describe('adapter contract behavior', () => {
+    it('Should propagate transport-level errors from the adapter', () => {
+      client.mock(() => Promise.reject(new Error('ECONNREFUSED')))
+      return client.getResource('myid')
+        .then(() => { assert.fail('Expected rejection') })
+        .catch(err => {
+          assert.equal(err.message, 'ECONNREFUSED')
+        })
+    })
+
+    it('Should not include transport headers in what is passed to the adapter', () => {
+      let capturedHeaders
+      client.mock((method, url, headers, body) => {
+        capturedHeaders = headers
+        return jsonResponse(200, { id: 'myid', object: 'my_resource' })
+      })
+      return client.getResource('myid').then(() => {
+        assert.equal(capturedHeaders['Accept-Encoding'], undefined)
+        assert.equal(capturedHeaders['Content-Length'], undefined)
+      })
+    })
+  })
+
   describe('with a response without a body', () => {
     it('Should throw a BadRequestError on 400', () => {
-      client.mock((resp, options) => {
-        resp.status = 400
-        resp.body = null
-        return Promise.resolve(resp)
-      })
-      return client
-        .listResources()
-        .count()
+      client.mock(() => emptyResponse(400))
+      return client.listResources().count()
         .catch(err => {
           assert(err instanceof recurly.errors.BadRequestError)
-
-          let options = sinon.match({
-            method: 'HEAD',
-            path: '/resources'
-          })
-          assert(client.calledWith(options, null))
+          assert(client.calledWith('HEAD', sinon.match('/resources')))
         })
     })
+
     it('Should throw a UnauthorizedError on 401', () => {
-      client.mock((resp, options) => {
-        resp.status = 401
-        resp.body = null
-        return Promise.resolve(resp)
-      })
-      return client
-        .listResources()
-        .count()
+      client.mock(() => emptyResponse(401))
+      return client.listResources().count()
         .catch(err => {
           assert(err instanceof recurly.errors.UnauthorizedError)
-
-          let options = sinon.match({
-            method: 'HEAD',
-            path: '/resources'
-          })
-          assert(client.calledWith(options, null))
+          assert(client.calledWith('HEAD', sinon.match('/resources')))
         })
     })
+
     it('Should throw a NotFoundError on 404', () => {
-      client.mock((resp, options) => {
-        resp.status = 404
-        resp.body = null
-        return Promise.resolve(resp)
-      })
-      return client
-        .listResources()
-        .count()
+      client.mock(() => emptyResponse(404))
+      return client.listResources().count()
         .catch(err => {
           assert(err instanceof recurly.errors.NotFoundError)
-
-          let options = sinon.match({
-            method: 'HEAD',
-            path: '/resources'
-          })
-          assert(client.calledWith(options, null))
+          assert(client.calledWith('HEAD', sinon.match('/resources')))
         })
     })
+
     it('Should throw a UnprocessableEntityError on 422', () => {
-      client.mock((resp, options) => {
-        resp.status = 422
-        resp.body = null
-        return Promise.resolve(resp)
-      })
-      return client
-        .listResources()
-        .count()
+      client.mock(() => emptyResponse(422))
+      return client.listResources().count()
         .catch(err => {
           assert(err instanceof recurly.errors.UnprocessableEntityError)
-
-          let options = sinon.match({
-            method: 'HEAD',
-            path: '/resources'
-          })
-          assert(client.calledWith(options, null))
+          assert(client.calledWith('HEAD', sinon.match('/resources')))
         })
     })
+
     it('Should throw a InternalServerError on 500', () => {
-      client.mock((resp, options) => {
-        resp.status = 500
-        resp.body = null
-        return Promise.resolve(resp)
-      })
-      return client
-        .listResources()
-        .count()
+      client.mock(() => emptyResponse(500))
+      return client.listResources().count()
         .catch(err => {
           assert(err instanceof recurly.errors.InternalServerError)
-
-          let options = sinon.match({
-            method: 'HEAD',
-            path: '/resources'
-          })
-          assert(client.calledWith(options, null))
+          assert(client.calledWith('HEAD', sinon.match('/resources')))
         })
     })
+
     it('Should throw a generic ApiError on an unhandled status', () => {
-      client.mock((resp, options) => {
-        resp.status = 426
-        resp.body = null
-        return Promise.resolve(resp)
-      })
-      return client
-        .listResources()
-        .count()
+      client.mock(() => emptyResponse(426))
+      return client.listResources().count()
         .catch(err => {
           assert(err instanceof recurly.ApiError)
-
-          let options = sinon.match({
-            method: 'HEAD',
-            path: '/resources'
-          })
-          assert(client.calledWith(options, null))
+          assert(client.calledWith('HEAD', sinon.match('/resources')))
         })
     })
   })

--- a/test/recurly/DefaultHttpAdapter.test.js
+++ b/test/recurly/DefaultHttpAdapter.test.js
@@ -1,0 +1,88 @@
+/* globals describe, it */
+
+require('../test_helper')
+const http = require('http')
+const net = require('net')
+const zlib = require('zlib')
+const assert = require('assert').strict
+const DefaultHttpAdapter = require('../../lib/recurly/DefaultHttpAdapter')
+const { runSuite } = require('../../lib/recurly/HttpAdapterContract')
+
+describe('DefaultHttpAdapter (contract suite)', () => {
+  runSuite(
+    () => new DefaultHttpAdapter({ timeout: 5000 }),
+    ({ name, run }) => it(name, run)
+  )
+})
+
+describe('DefaultHttpAdapter (ECONNRESET retry)', () => {
+  it('retries once on ECONNRESET and resolves on second attempt', done => {
+    let attempts = 0
+
+    // First connection: accept, then immediately destroy (simulates ECONNRESET)
+    // Second connection: serve a valid response
+    const server = net.createServer((socket) => {
+      attempts++
+      if (attempts === 1) {
+        socket.destroy()
+      } else {
+        socket.write(
+          'HTTP/1.1 200 OK\r\n' +
+          'Content-Type: application/json\r\n' +
+          'Content-Length: 11\r\n' +
+          'Connection: close\r\n' +
+          '\r\n' +
+          '{"ok":true}'
+        )
+        socket.end()
+      }
+    })
+
+    server.listen(0, '127.0.0.1', async () => {
+      const { address, port } = server.address()
+      const adapter = new DefaultHttpAdapter({ timeout: 5000 })
+      try {
+        const resp = await adapter.execute('GET', `http://${address}:${port}/test`, {}, null)
+        assert.equal(attempts, 2)
+        assert.equal(resp.statusCode, 200)
+        assert.equal(resp.body, '{"ok":true}')
+        done()
+      } catch (err) {
+        done(err)
+      } finally {
+        server.close()
+      }
+    })
+  })
+})
+
+describe('DefaultHttpAdapter (gzip)', () => {
+  it('decodes a gzip-encoded response body', done => {
+    const payload = Buffer.from('{"gzipped":true}')
+    const server = http.createServer((req, res) => {
+      zlib.gzip(payload, (err, compressed) => {
+        if (err) { res.writeHead(500, {}); res.end(''); return }
+        res.writeHead(200, {
+          'content-encoding': 'gzip',
+          'content-type': 'application/json',
+          'content-length': compressed.length
+        })
+        res.end(compressed)
+      })
+    })
+
+    server.listen(0, '127.0.0.1', async () => {
+      const { address, port } = server.address()
+      const adapter = new DefaultHttpAdapter({ timeout: 5000 })
+      try {
+        const resp = await adapter.execute('GET', `http://${address}:${port}/gzip`, {}, null)
+        assert.equal(resp.body, '{"gzipped":true}')
+        done()
+      } catch (err) {
+        done(err)
+      } finally {
+        server.close()
+      }
+    })
+  })
+})

--- a/test/recurly/Http.test.js
+++ b/test/recurly/Http.test.js
@@ -3,6 +3,7 @@
 require('../test_helper')
 const assert = require('assert').strict
 const { Request, Response } = require('../../lib/recurly/Http')
+const { HttpResponse } = require('../../lib/recurly/HttpAdapter')
 
 describe('Http', () => {
   describe('Request', () => {
@@ -16,27 +17,26 @@ describe('Http', () => {
     })
   })
   describe('Response', () => {
-    describe('.build', () => {
-      let mockHttpResponse = () => {
-        return {
-          statusCode: 200,
-          headers: {
-            'x-request-id': 'requestid',
-            'x-ratelimit-limit': 2000,
-            'x-ratelimit-remaining': 1999,
-            'x-ratelimit-reset': 1571948450,
-            'Recurly-Deprecated': 'false',
-            'date': 'Monday',
-            'server': 'cloudflare',
-            'cf-ray': 'cf-1234',
-            'content-type': 'application/json; charset=utf-8'
-          }
-        }
+    describe('.fromHttpResponse', () => {
+      let makeHttpResponse = (overrides = {}) => {
+        const headers = Object.assign({
+          'x-request-id': 'requestid',
+          'x-ratelimit-limit': '2000',
+          'x-ratelimit-remaining': '1999',
+          'x-ratelimit-reset': '1571948450',
+          'recurly-deprecated': 'false',
+          'date': 'Monday',
+          'server': 'cloudflare',
+          'cf-ray': 'cf-1234',
+          'content-type': 'application/json; charset=utf-8'
+        }, overrides.headers || {})
+        return new HttpResponse(overrides.statusCode || 200, headers, overrides.body !== undefined ? overrides.body : null)
       }
+
       it('Should properly build a response', () => {
         const req = new Request('GET', '/path', { property: 123 })
-        const bodyChunks = ['{ "id": "myid", "object": "my_resource" }']
-        const resp = Response.build(mockHttpResponse(), bodyChunks, req)
+        const httpResp = makeHttpResponse({ body: '{ "id": "myid", "object": "my_resource" }' })
+        const resp = Response.fromHttpResponse(httpResp, req)
         assert.equal(resp.request, req)
         assert.equal(resp.status, 200)
         assert.deepEqual(JSON.parse(resp.body), { id: 'myid', object: 'my_resource' })
@@ -49,26 +49,28 @@ describe('Http', () => {
         assert.equal(resp.proxyMetadata['cf-ray'], 'cf-1234')
         assert.equal(resp.apiDeprecated, false)
       })
+
       it('Should keep the body null if there is no body', () => {
         const req = new Request('GET', '/path', { property: 123 })
-        const bodyChunks = []
-        const resp = Response.build(mockHttpResponse(), bodyChunks, req)
+        const httpResp = makeHttpResponse({ body: null })
+        const resp = Response.fromHttpResponse(httpResp, req)
         assert.equal(resp.body, null)
       })
+
       it('Should set apiDeprecated to true and sunset if headers exist', () => {
         const req = new Request('GET', '/path', { property: 123 })
-        const mockResp = mockHttpResponse()
-        mockResp.headers['Recurly-Deprecated'] = 'true'
-        mockResp.headers['Recurly-Sunset-Date'] = 'Tuesday'
-        const resp = Response.build(mockResp, null, req)
+        const httpResp = makeHttpResponse({
+          headers: { 'recurly-deprecated': 'TRUE', 'recurly-sunset-date': 'Tuesday' }
+        })
+        const resp = Response.fromHttpResponse(httpResp, req)
         assert.equal(resp.apiDeprecated, true)
         assert.equal(resp.apiSunsetDate, 'Tuesday')
       })
+
       it('Should set recordCount if recurly-total-records header is present', () => {
         const req = new Request('GET', '/path', { property: 123 })
-        const mockResp = mockHttpResponse()
-        mockResp.headers['recurly-total-records'] = '9000'
-        const resp = Response.build(mockResp, null, req)
+        const httpResp = makeHttpResponse({ headers: { 'recurly-total-records': '9000' } })
+        const resp = Response.fromHttpResponse(httpResp, req)
         assert.equal(resp.recordCount, 9000)
       })
     })

--- a/test/recurly/Pager.test.js
+++ b/test/recurly/Pager.test.js
@@ -3,7 +3,8 @@
 require('../test_helper')
 const { MyResource } = require('../mock_resources')
 const assert = require('assert').strict
-const MockClient = require('../mock_client')
+const { MockClient } = require('../mock_client')
+const { HttpResponse, jsonResponse } = require('../http_test_helpers')
 const Pager = require('../../lib/recurly/Pager')
 
 const client = new MockClient('myapikey')
@@ -19,16 +20,14 @@ describe('Pager', () => {
   })
 
   afterEach(() => {
-    // completely restore all fakes
     client.restore()
   })
 
   describe('#first', () => {
     beforeEach(() => {
-      client.mock((resp, options) => {
-        if (options.method === 'GET' && options.path === '/resources?limit=1') {
-          resp.status = 200
-          resp.body = JSON.stringify({
+      client.mock((method, url, headers, body) => {
+        if (method === 'GET' && url.includes('/resources?limit=1')) {
+          return jsonResponse(200, {
             object: 'list',
             has_more: false,
             next: null,
@@ -38,11 +37,8 @@ describe('Pager', () => {
               { id: '3', object: 'my_resource' }
             ]
           })
-        } else {
-          resp.status = 404
-          resp.body = { error: { type: 'not_found' } }
         }
-        return Promise.resolve(resp)
+        return jsonResponse(404, { error: { type: 'not_found' } })
       })
     })
 
@@ -57,15 +53,11 @@ describe('Pager', () => {
 
   describe('#count', () => {
     beforeEach(() => {
-      client.mock((resp, options) => {
-        if (options.method === 'HEAD' && options.path === '/resources?sort=updated_at') {
-          resp.status = 200
-          resp.recordCount = 9000
-        } else {
-          resp.status = 404
-          resp.body = JSON.stringify({ error: { type: 'not_found' } })
+      client.mock((method, url, headers, body) => {
+        if (method === 'HEAD' && url.includes('/resources?sort=updated_at')) {
+          return Promise.resolve(new HttpResponse(200, { 'recurly-total-records': '9000' }, null))
         }
-        return Promise.resolve(resp)
+        return jsonResponse(404, { error: { type: 'not_found' } })
       })
     })
 
@@ -79,10 +71,19 @@ describe('Pager', () => {
 
   describe('with multiple pages', () => {
     beforeEach(() => {
-      client.mock((resp, options) => {
-        if (options.path === '/resources?state=active&limit=3') {
-          resp.status = 200
-          resp.body = JSON.stringify({
+      client.mock((method, url, headers, body) => {
+        if (url.includes('/resources?state=active&limit=3&cursor=1234567890')) {
+          return jsonResponse(200, {
+            object: 'list',
+            has_more: false,
+            next: '',
+            data: [
+              { id: 3, object: 'my_resource' },
+              { id: 4, object: 'my_resource' }
+            ]
+          })
+        } else if (url.includes('/resources?state=active&limit=3')) {
+          return jsonResponse(200, {
             object: 'list',
             has_more: true,
             next: '/resources?state=active&limit=3&cursor=1234567890',
@@ -92,24 +93,11 @@ describe('Pager', () => {
               { id: 2, object: 'my_resource' }
             ]
           })
-        } else if (options.path === '/resources?state=active&limit=3&cursor=1234567890') {
-          resp.status = 200
-          resp.body = JSON.stringify({
-            object: 'list',
-            has_more: false,
-            next: '',
-            data: [
-              { id: 3, object: 'my_resource' },
-              { id: 4, object: 'my_resource' }
-            ]
-          })
-        } else {
-          resp.status = 404
-          resp.body = { error: { type: 'not_found' } }
         }
-        return Promise.resolve(resp)
+        return jsonResponse(404, { error: { type: 'not_found' } })
       })
     })
+
     describe('#each', () => {
       it('Should return an asynciterable', () => {
         assert(typeof pager.each === 'function')
@@ -129,6 +117,7 @@ describe('Pager', () => {
         })()
       })
     })
+
     describe('#eachPage', () => {
       it('Should return an asynciterable', () => {
         assert(typeof pager.eachPage === 'function')


### PR DESCRIPTION
## Summary

- Introduces `HttpAdapter` abstract base class with a single `execute(method, url, headers, body)` method that returns `Promise<HttpResponse>`
- Adds `DefaultHttpAdapter` (built-in implementation) which owns gzip/deflate decoding, `Content-Length`, keep-alive agents, timeout, and ECONNRESET retry — extracted from the previous `Http.makeRequest` and `BaseClient` logic
- Constructor injection: `new Client(apiKey, { httpAdapter: adapter })` — validated as `instanceof HttpAdapter`, defaults to `DefaultHttpAdapter`
- Exports `HttpAdapter`, `DefaultHttpAdapter`, `HttpMethod`, and `HttpResponse` from the top-level `recurly` module
- Adds `lib/testing.js` entry point exposing `HttpAdapterContract.runSuite` for adapter authors to verify their implementation
- Updates `MockClient`, `BaseClient.test.js`, `Http.test.js`, and `Pager.test.js` to the new adapter-based transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)